### PR TITLE
feat: cli for generating projects and migrating schema

### DIFF
--- a/.github/workflows/cli-build.yml
+++ b/.github/workflows/cli-build.yml
@@ -1,0 +1,44 @@
+name: CLI Build
+
+on:
+    push:
+        branches: [main]
+        paths: ["cli/**"]
+    pull_request:
+        paths: ["cli/**"]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              working-directory: ./cli
+              run: bun install
+
+            - name: Type check
+              working-directory: ./cli
+              run: bun run typecheck
+
+            - name: Build CLI
+              working-directory: ./cli
+              run: bun run build
+
+            - name: Check build artifacts
+              working-directory: ./cli
+              run: |
+                  ls -la dist/
+                  test -f dist/index.js

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -1,0 +1,38 @@
+name: CLI Tests
+
+on:
+    push:
+        branches: [main]
+        paths: ["cli/**"]
+    pull_request:
+        paths: ["cli/**"]
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+
+            - name: Install dependencies
+              working-directory: ./cli
+              run: bun install
+
+            - name: Run tests
+              working-directory: ./cli
+              run: bun test
+
+            - name: Type check
+              working-directory: ./cli
+              run: bun run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 dist
 pnpm-lock.yaml
+bun.lock

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Demo implementations are available in the [`examples/`](./examples/) directory f
 - [x] R2
 - [ ] Cloudflare Images
 - [ ] Durable Objects
+- [x] CLI for project setup and Cloudflare resources setup
+- [x] CLI for database schema and migration management
 
 **Examples:**
 
@@ -70,6 +72,16 @@ pnpm add better-auth-cloudflare
 # or
 bun add better-auth-cloudflare
 ```
+
+### Quick Start with CLI
+
+For the fastest setup, use the CLI to generate a complete project with Cloudflare resources:
+
+```bash
+npx @better-auth-cloudflare/cli
+```
+
+The CLI creates projects from Hono or Next.js templates and can automatically set up D1, KV, R2, and Hyperdrive resources. See [cli/README.md](./cli/README.md) for full documentation.
 
 ## Configuration Options
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,110 @@
+# @better-auth-cloudflare/cli
+
+## Usage
+
+```bash
+npx @better-auth-cloudflare/cli                         # Run interactive generator
+npx @better-auth-cloudflare/cli generate                # Run interactive generator
+npx @better-auth-cloudflare/cli migrate                 # Run migration workflow
+npx @better-auth-cloudflare/cli --app-name=my-app ...   # Run with arguments
+bunx @better-auth-cloudflare/cli --app-name=my-app ...  # Run with arguments
+```
+
+## Arguments
+
+```
+--app-name=<name>              Project name (default: my-app)
+--template=<template>          hono | nextjs (default: hono)
+--database=<db>                d1 | hyperdrive-postgres | hyperdrive-mysql (default: d1)
+--geolocation=<bool>           Enable geolocation tracking (default: true)
+--kv=<bool>                    Use KV storage (default: true)
+--r2=<bool>                    Enable R2 storage (default: false)
+```
+
+### Database-specific arguments
+
+```
+--d1-name=<name>               D1 database name (default: <app-name>-db)
+--d1-binding=<binding>         D1 binding name (default: DATABASE)
+--hd-name=<name>               Hyperdrive instance name (default: <app-name>-hyperdrive)
+--hd-binding=<binding>         Hyperdrive binding name (default: HYPERDRIVE)
+--hd-connection-string=<url>   Database connection string (required for hyperdrive)
+```
+
+### Storage arguments
+
+```
+--kv-binding=<binding>         KV binding name (default: KV)
+--kv-namespace-name=<name>     KV namespace name (default: <app-name>-kv)
+--r2-binding=<binding>         R2 binding name (default: R2_BUCKET)
+--r2-bucket-name=<name>        R2 bucket name (default: <app-name>-files)
+```
+
+### Cloudflare account arguments
+
+```
+--account-id=<id>              Cloudflare account ID (for non-interactive mode)
+--skip-cloudflare-setup=<bool> Skip Cloudflare resource creation (default: false)
+--apply-migrations=<choice>    Apply D1 migrations: dev | prod | skip (default: skip)
+```
+
+### Migrate command arguments
+
+```
+--migrate-target=<target>      For migrate command: dev | remote | skip (default: skip)
+```
+
+## Examples
+
+Create a Hono app with D1 database:
+
+```bash
+npx @better-auth-cloudflare/cli --app-name=my-hono-app --template=hono --database=d1
+```
+
+Create a Next.js app with PostgreSQL via Hyperdrive:
+
+```bash
+npx @better-auth-cloudflare/cli --app-name=my-next-app --template=nextjs \
+  --database=hyperdrive-postgres --hd-connection-string=postgres://user:pass@host:5432/db
+```
+
+Create app without KV or R2:
+
+```bash
+npx @better-auth-cloudflare/cli --app-name=minimal-app --kv=false --r2=false
+```
+
+Skip Cloudflare setup (useful for CI/CD):
+
+```bash
+npx @better-auth-cloudflare/cli --app-name=ci-app --skip-cloudflare-setup=true
+```
+
+Specify account ID for non-interactive mode:
+
+```bash
+npx @better-auth-cloudflare/cli --app-name=prod-app --account-id=your-account-id
+```
+
+Apply migrations automatically in non-interactive mode:
+
+```bash
+npx @better-auth-cloudflare/cli --app-name=auto-app --apply-migrations=dev
+```
+
+Run migration workflow interactively:
+
+```bash
+npx @better-auth-cloudflare/cli migrate
+```
+
+Run migration workflow with non-interactive target:
+
+```bash
+npx @better-auth-cloudflare/cli migrate --migrate-target=dev
+```
+
+---
+
+Creates a new Better Auth Cloudflare project from Hono or OpenNext.js templates, optionally creating Cloudflare D1, KV, R2, or Hyperdrive resources for you. The migrate command runs `auth:update`, `db:generate`, and optionally `db:migrate`.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@better-auth-cloudflare/cli",
+    "version": "0.1.0",
+    "description": "CLI to generate Better Auth Cloudflare projects (Hono or OpenNext.js)",
+    "author": "better-auth-cloudflare",
+    "license": "MIT",
+    "private": false,
+    "bin": {
+        "better-auth-cloudflare": "dist/index.js"
+    },
+    "type": "commonjs",
+    "files": [
+        "dist/**/*"
+    ],
+    "scripts": {
+        "build": "tsc -p tsconfig.json",
+        "dev": "node --enable-source-maps dist/index.js",
+        "typecheck": "tsc -p tsconfig.json --noEmit",
+        "test": "bun test",
+        "prepublishOnly": "npm run build"
+    },
+    "dependencies": {
+        "@clack/prompts": "^0.7.0",
+        "picocolors": "^1.0.0"
+    },
+    "devDependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@types/node": "^22.7.5",
+        "bun-types": "^1.1.33",
+        "typescript": "^5.5.4"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,1430 @@
+#!/usr/bin/env node
+
+import { cancel, confirm, group, intro, outro, select, spinner, text } from "@clack/prompts";
+import { cpSync, existsSync, mkdtempSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import pc from "picocolors";
+
+type DbKind = "d1" | "hyperdrive-postgres" | "hyperdrive-mysql";
+
+interface GenerateAnswers {
+    appName: string;
+    template: "hono" | "nextjs";
+    database: DbKind;
+    // D1
+    d1Name?: string;
+    d1Binding?: string;
+    // Hyperdrive
+    hdBinding?: string;
+    hdName?: string;
+    hdConnectionString?: string;
+    // Features
+    geolocation: boolean;
+    kv: boolean;
+    kvBinding?: string;
+    kvNamespaceName?: string;
+    r2: boolean;
+    r2Binding?: string;
+    r2BucketName?: string;
+    // Cloudflare account configuration
+    accountId?: string;
+    skipCloudflareSetup?: boolean;
+    // Migration options
+    applyMigrations?: "dev" | "prod" | "skip";
+}
+
+interface CliArgs {
+    [key: string]: string | boolean | undefined;
+}
+
+// JSON typing helpers (avoid any/unknown)
+export type JSONValue = string | number | boolean | null | JSONArray | JSONObject;
+export interface JSONObject {
+    [key: string]: JSONValue;
+}
+export interface JSONArray extends Array<JSONValue> {}
+
+type PackageManager = "bun" | "pnpm" | "yarn" | "npm";
+
+function bunSpawnSync(command: string, args: string[], cwd?: string, env?: Record<string, string>) {
+    try {
+        if (typeof Bun !== "undefined" && typeof Bun.spawnSync === "function") {
+            const res = Bun.spawnSync({
+                cmd: [command, ...args],
+                cwd,
+                stdout: "pipe",
+                stderr: "pipe",
+                env: env ? { ...process.env, ...env } : process.env,
+            });
+            const decode = (b: Uint8Array | undefined) => (b ? new TextDecoder().decode(b) : "");
+            return { code: res.exitCode ?? 0, stdout: decode(res.stdout), stderr: decode(res.stderr) };
+        }
+    } catch {}
+    // Fallback to Node's child_process
+    const { spawnSync } = require("child_process") as typeof import("child_process");
+    const result = spawnSync(command, args, {
+        stdio: "pipe",
+        cwd,
+        encoding: "utf8",
+        env: env ? { ...process.env, ...env } : process.env,
+    });
+    return { code: result.status ?? 1, stdout: result.stdout, stderr: result.stderr };
+}
+
+function commandAvailable(command: string): boolean {
+    const res = bunSpawnSync(command, ["--version"]);
+    return (res.code ?? 1) === 0;
+}
+
+function fatal(message: string, details?: string) {
+    if (details && details.trim()) process.stdout.write(details);
+    outro(pc.red(message));
+    process.exit(1);
+}
+
+function assertOk(result: { code: number; stdout?: string; stderr?: string }, failMessage: string) {
+    if (result.code !== 0) fatal(failMessage, result.stderr || result.stdout || "");
+}
+
+function detectPackageManager(cwd: string): PackageManager {
+    if (existsSync(join(cwd, "bun.lockb")) && commandAvailable("bun")) return "bun";
+    if (existsSync(join(cwd, "pnpm-lock.yaml")) && commandAvailable("pnpm")) return "pnpm";
+    if (existsSync(join(cwd, "yarn.lock")) && commandAvailable("yarn")) return "yarn";
+    if (commandAvailable("bun")) return "bun";
+    if (commandAvailable("pnpm")) return "pnpm";
+    if (commandAvailable("yarn")) return "yarn";
+    return "npm";
+}
+
+function runScript(pm: PackageManager, script: string, cwd: string) {
+    const args = pm === "bun" ? ["run", script] : pm === "yarn" ? [script] : ["run", script];
+    return bunSpawnSync(pm, args, cwd);
+}
+
+function runInstall(pm: PackageManager, cwd: string) {
+    const args = pm === "yarn" ? [] : ["install"];
+    return bunSpawnSync(pm, args, cwd);
+}
+
+function runWranglerCommand(args: string[], cwd: string, accountId?: string) {
+    const env = accountId ? { CLOUDFLARE_ACCOUNT_ID: accountId } : undefined;
+    return bunSpawnSync("npx", ["wrangler", ...args], cwd, env);
+}
+
+function parseAvailableAccounts(stderr: string): Array<{ name: string; id: string }> {
+    const accounts: Array<{ name: string; id: string }> = [];
+    const lines = stderr.split("\n");
+
+    for (const line of lines) {
+        // Parse lines like: `Account Name`: `account-id`
+        const match = line.match(/^\s*`([^`]+)`:\s*`([^`]+)`$/);
+        if (match) {
+            accounts.push({ name: match[1], id: match[2] });
+        }
+    }
+
+    return accounts;
+}
+
+async function handleAccountSelection(stderr: string, isNonInteractive: boolean): Promise<string | undefined> {
+    const accounts = parseAvailableAccounts(stderr);
+
+    if (accounts.length === 0) {
+        return undefined;
+    }
+
+    if (isNonInteractive) {
+        // In non-interactive mode, show available accounts and exit with instructions
+        outro(pc.red("Multiple Cloudflare accounts found. Please specify which account to use."));
+        console.log(pc.bold("\nAvailable accounts:"));
+        for (const account of accounts) {
+            console.log(`  ${pc.cyan(account.name)}: ${pc.gray(account.id)}`);
+        }
+        console.log(pc.bold("\nTo use a specific account, add the --account-id argument:"));
+        console.log(pc.cyan(`  --account-id=${accounts[0].id}`));
+        console.log(pc.bold("\nOr skip Cloudflare setup entirely:"));
+        console.log(pc.cyan("  --skip-cloudflare-setup=true"));
+        process.exit(1);
+    } else {
+        // In interactive mode, let user select
+        const { select } = await import("@clack/prompts");
+        const selectedAccountId = (await (select as any)({
+            message: "Multiple Cloudflare accounts found. Which account would you like to use?",
+            options: accounts.map(account => ({
+                value: account.id,
+                label: `${account.name} (${account.id})`,
+            })),
+        })) as string;
+
+        return selectedAccountId;
+    }
+}
+
+async function ensureWranglerAuth(isNonInteractive: boolean): Promise<string | undefined> {
+    // Check if user is already authenticated
+    const whoamiResult = bunSpawnSync("npx", ["wrangler", "whoami"]);
+
+    if (whoamiResult.code === 0) {
+        // Already authenticated, return undefined (no specific account needed)
+        return undefined;
+    }
+
+    if (isNonInteractive) {
+        // In non-interactive mode, show login instructions and exit
+        outro(pc.red("Wrangler authentication required for Cloudflare setup."));
+        console.log(pc.bold("\nTo authenticate, run:"));
+        console.log(pc.cyan("  npx wrangler login"));
+        console.log(pc.bold("\nOr skip Cloudflare setup:"));
+        console.log(pc.cyan("  --skip-cloudflare-setup=true"));
+        process.exit(1);
+    } else {
+        // In interactive mode, prompt to login
+        const shouldLoginResult = await confirm({
+            message: "Wrangler authentication required. Login now?",
+            initialValue: true,
+        });
+        const shouldLogin = shouldLoginResult === true;
+
+        if (shouldLogin) {
+            const s = spinner();
+            s.start("Opening browser for Wrangler login...");
+
+            const loginResult = bunSpawnSync("npx", ["wrangler", "login"]);
+
+            if (loginResult.code === 0) {
+                s.stop(pc.green("Successfully logged in to Wrangler."));
+                return undefined;
+            } else {
+                s.stop(pc.red("Failed to login to Wrangler."));
+                fatal("Wrangler login failed. Please try running 'npx wrangler login' manually.");
+            }
+        } else {
+            outro(
+                pc.yellow(
+                    "Skipping Cloudflare setup. You can run 'npx wrangler login' and setup resources manually later."
+                )
+            );
+            return "skip-setup";
+        }
+    }
+}
+
+function ensureCleanAppDir(appDir: string) {
+    if (existsSync(appDir)) {
+        throw new Error(`Directory ${appDir} already exists. Choose a different name or remove it.`);
+    }
+}
+
+function replaceAll(content: string, replacements: Record<string, string>) {
+    let out = content;
+    for (const [key, value] of Object.entries(replacements)) {
+        out = out.split(key).join(value);
+    }
+    return out;
+}
+
+export function updateJSON(filePath: string, mutator: (json: JSONObject) => JSONObject) {
+    const json = JSON.parse(readFileSync(filePath, "utf8")) as JSONObject;
+    const next = mutator(json);
+    writeFileSync(filePath, JSON.stringify(next, null, 2));
+}
+
+export function extractFirstBlock(toml: string, header: string) {
+    const re = new RegExp(`(\\[\\[${header}\\]\\][\\s\\S]*?)(?=\\n\\[\\[|$)`);
+    const match = re.exec(toml);
+    if (!match) return null;
+    return { block: match[1], start: match.index, end: match.index + match[1].length };
+}
+
+export function updateD1Block(toml: string, binding: string, dbName: string) {
+    const found = extractFirstBlock(toml, "d1_databases");
+    if (!found) return toml;
+    let block = found.block;
+    if (/binding\s*=\s*"[^"]+"/.test(block)) {
+        block = block.replace(/binding\s*=\s*"[^"]+"/, `binding = "${binding}"`);
+    } else {
+        block = block.replace(/\[\[d1_databases\]\]/, `[[d1_databases]]\nbinding = "${binding}"`);
+    }
+    if (/database_name\s*=\s*"[^"]+"/.test(block)) {
+        block = block.replace(/database_name\s*=\s*"[^"]+"/, `database_name = "${dbName}"`);
+    }
+    return toml.slice(0, found.start) + block + toml.slice(found.end);
+}
+
+export function appendOrReplaceKvNamespaceBlock(toml: string, binding: string, id?: string) {
+    const kvBlockRegex = /\[\[kv_namespaces\]\][\s\S]*?(?=(\n\[\[|$))/g;
+    const blocks = toml.match(kvBlockRegex) || [];
+    const newBlock = ["[[kv_namespaces]]", `binding = "${binding}"`, id ? `id = "${id}"` : ""]
+        .filter(Boolean)
+        .join("\n");
+
+    const existingIndex = blocks.findIndex(b => b.includes(`binding = "${binding}"`));
+    if (existingIndex >= 0) {
+        const existing = blocks[existingIndex];
+        return toml.replace(existing, newBlock);
+    }
+    return toml.trimEnd() + "\n\n" + newBlock + "\n";
+}
+
+export function appendOrReplaceR2Block(toml: string, binding: string, bucketName: string) {
+    const r2BlockRegex = /\[\[r2_buckets\]\][\s\S]*?(?=(\n\[\[|$))/g;
+    const blocks = toml.match(r2BlockRegex) || [];
+    const newBlock = ["[[r2_buckets]]", `binding = "${binding}"`, `bucket_name = "${bucketName}"`].join("\n");
+    const existingIndex = blocks.findIndex(b => b.includes(`binding = "${binding}"`));
+    if (existingIndex >= 0) {
+        const existing = blocks[existingIndex];
+        return toml.replace(existing, newBlock);
+    }
+    return toml.trimEnd() + "\n\n" + newBlock + "\n";
+}
+
+export function appendOrReplaceHyperdriveBlock(toml: string, binding: string, id: string) {
+    const blockRegex = /\[\[hyperdrive\]\][\s\S]*?(?=(\n\[\[|$))/g;
+    const blocks = toml.match(blockRegex) || [];
+    const newBlock = ["[[hyperdrive]]", `binding = "${binding}"`, `id = "${id}"`].join("\n");
+    const existingIndex = blocks.findIndex(b => b.includes(`binding = "${binding}"`));
+    if (existingIndex >= 0) {
+        const existing = blocks[existingIndex];
+        return toml.replace(existing, newBlock);
+    }
+    return toml.trimEnd() + "\n\n" + newBlock + "\n";
+}
+
+export function clearAllR2Blocks(toml: string) {
+    return toml.replace(/\[\[r2_buckets\]\][\s\S]*?(?=(\n\[\[|$))/g, "");
+}
+
+export function clearAllKvBlocks(toml: string) {
+    return toml.replace(/\[\[kv_namespaces\]\][\s\S]*?(?=(\n\[\[|$))/g, "");
+}
+
+function tryUpdateFile(filePath: string, mutate: (content: string) => string) {
+    if (!existsSync(filePath)) return;
+    const src = readFileSync(filePath, "utf8");
+    const next = mutate(src);
+    if (next !== src) writeFileSync(filePath, next);
+}
+
+export function validateBindingName(name: string): string | undefined {
+    if (!name || name.trim().length === 0) return "Please enter a binding name";
+    if (!/^[A-Z0-9_]+$/.test(name)) return "Use ONLY A-Z, 0-9, and underscores";
+    return undefined;
+}
+
+function parseCliArgs(argv: string[]): CliArgs {
+    const args: CliArgs = {};
+
+    for (let i = 2; i < argv.length; i++) {
+        const arg = argv[i];
+
+        // Handle --key=value format
+        if (arg.startsWith("--") && arg.includes("=")) {
+            const [key, ...valueParts] = arg.slice(2).split("=");
+            const value = valueParts.join("="); // Handle values that contain "="
+
+            // Convert boolean strings
+            if (value === "true") {
+                args[key] = true;
+            } else if (value === "false") {
+                args[key] = false;
+            } else {
+                args[key] = value;
+            }
+        }
+        // Handle --key value format
+        else if (arg.startsWith("--") && i + 1 < argv.length && !argv[i + 1].startsWith("--")) {
+            const key = arg.slice(2);
+            const value = argv[i + 1];
+
+            // Convert boolean strings
+            if (value === "true") {
+                args[key] = true;
+            } else if (value === "false") {
+                args[key] = false;
+            } else {
+                args[key] = value;
+            }
+            i += 1; // Skip the next argument as it's the value
+        }
+        // Handle boolean flags like --geolocation (defaults to true)
+        else if (arg.startsWith("--")) {
+            const key = arg.slice(2);
+            args[key] = true;
+        }
+    }
+
+    return args;
+}
+
+function validateCliArgs(args: CliArgs): string[] {
+    const errors: string[] = [];
+
+    // Validate app name
+    if (args["app-name"] && typeof args["app-name"] === "string") {
+        const name = args["app-name"];
+        if (!name.trim()) {
+            errors.push("app-name cannot be empty");
+        } else if (!/^[a-z0-9-]+$/.test(name)) {
+            errors.push("app-name must contain only lowercase letters, numbers, and hyphens");
+        }
+    }
+
+    // Validate template
+    if (args.template && !["hono", "nextjs"].includes(args.template as string)) {
+        errors.push("template must be 'hono' or 'nextjs'");
+    }
+
+    // Validate database
+    if (args.database && !["d1", "hyperdrive-postgres", "hyperdrive-mysql"].includes(args.database as string)) {
+        errors.push("database must be 'd1', 'hyperdrive-postgres', or 'hyperdrive-mysql'");
+    }
+
+    // Validate binding names
+    const bindingFields = ["d1-binding", "hd-binding", "kv-binding", "r2-binding"];
+    for (const field of bindingFields) {
+        if (args[field] !== undefined && typeof args[field] === "string") {
+            const error = validateBindingName(String(args[field]));
+            if (error) {
+                errors.push(`${field}: ${error}`);
+            }
+        }
+    }
+
+    // Validate connection string format if provided
+    if (args["hd-connection-string"] && typeof args["hd-connection-string"] === "string") {
+        const connStr = args["hd-connection-string"];
+        if (
+            !connStr.startsWith("postgres://") &&
+            !connStr.startsWith("postgresql://") &&
+            !connStr.startsWith("mysql://")
+        ) {
+            errors.push(
+                "hd-connection-string must be a valid database URL starting with postgres://, postgresql://, or mysql://"
+            );
+        }
+    }
+
+    // Validate apply-migrations option
+    if (args["apply-migrations"] && !["dev", "prod", "skip"].includes(args["apply-migrations"] as string)) {
+        errors.push("apply-migrations must be 'dev', 'prod', or 'skip'");
+    }
+
+    return errors;
+}
+
+function cliArgsToAnswers(args: CliArgs): Partial<GenerateAnswers> {
+    const answers: Partial<GenerateAnswers> = {};
+
+    if (args["app-name"]) answers.appName = args["app-name"] as string;
+    if (args.template) answers.template = args.template as "hono" | "nextjs";
+    if (args.database) answers.database = args.database as DbKind;
+
+    // D1 fields
+    if (args["d1-name"]) answers.d1Name = args["d1-name"] as string;
+    if (args["d1-binding"]) answers.d1Binding = args["d1-binding"] as string;
+
+    // Hyperdrive fields
+    if (args["hd-binding"]) answers.hdBinding = args["hd-binding"] as string;
+    if (args["hd-name"]) answers.hdName = args["hd-name"] as string;
+    if (args["hd-connection-string"]) answers.hdConnectionString = args["hd-connection-string"] as string;
+
+    // Features
+    if (args.geolocation !== undefined) answers.geolocation = Boolean(args.geolocation);
+    if (args.kv !== undefined) answers.kv = Boolean(args.kv);
+    if (args["kv-binding"]) answers.kvBinding = args["kv-binding"] as string;
+    if (args["kv-namespace-name"]) answers.kvNamespaceName = args["kv-namespace-name"] as string;
+    if (args.r2 !== undefined) answers.r2 = Boolean(args.r2);
+    if (args["r2-binding"]) answers.r2Binding = args["r2-binding"] as string;
+    if (args["r2-bucket-name"]) answers.r2BucketName = args["r2-bucket-name"] as string;
+
+    // Cloudflare account configuration
+    if (args["account-id"]) answers.accountId = args["account-id"] as string;
+    if (args["skip-cloudflare-setup"] !== undefined)
+        answers.skipCloudflareSetup = Boolean(args["skip-cloudflare-setup"]);
+
+    // Migration options
+    if (args["apply-migrations"] && ["dev", "prod", "skip"].includes(args["apply-migrations"] as string)) {
+        answers.applyMigrations = args["apply-migrations"] as "dev" | "prod" | "skip";
+    }
+
+    return answers;
+}
+
+async function migrate(cliArgs?: CliArgs) {
+    intro(`${pc.bold("Better Auth Cloudflare")} ${pc.gray("· migrate")}`);
+
+    // Check if we're in a project directory by looking for project.config.json
+    const configPath = join(process.cwd(), "project.config.json");
+    if (!existsSync(configPath)) {
+        fatal("No project.config.json found. Please run this command from a Better Auth Cloudflare project directory.");
+    }
+
+    // Read project config to get project details
+    let projectConfig: JSONObject;
+    try {
+        projectConfig = JSON.parse(readFileSync(configPath, "utf8")) as JSONObject;
+    } catch (e) {
+        fatal("Failed to read project.config.json");
+        return; // This line will never be reached due to fatal(), but satisfies TypeScript
+    }
+
+    const pm = detectPackageManager(process.cwd());
+    const isNonInteractive = Boolean(cliArgs && Object.keys(cliArgs).length > 0);
+
+    // Run auth:update
+    const authSpinner = spinner();
+    authSpinner.start("Running auth:update...");
+    const authRes = runScript(pm, "auth:update", process.cwd());
+    if (authRes.code === 0) {
+        authSpinner.stop(pc.green("Auth schema updated."));
+    } else {
+        authSpinner.stop(pc.red("Failed to update auth schema."));
+        assertOk(authRes, "Auth schema update failed.");
+    }
+
+    // Run db:generate
+    const dbSpinner = spinner();
+    dbSpinner.start("Running db:generate...");
+    const dbRes = runScript(pm, "db:generate", process.cwd());
+    if (dbRes.code === 0) {
+        dbSpinner.stop(pc.green("Database migrations generated."));
+    } else {
+        dbSpinner.stop(pc.red("Failed to generate database migrations."));
+        assertOk(dbRes, "Database migration generation failed.");
+    }
+
+    // Only ask about db:migrate if database is D1
+    const database = projectConfig.database as string;
+    if (database === "d1") {
+        let migrateChoice: "dev" | "remote" | "skip" = "skip";
+
+        if (isNonInteractive) {
+            // Check for CLI argument
+            if (cliArgs && cliArgs["migrate-target"]) {
+                const target = cliArgs["migrate-target"] as string;
+                if (["dev", "remote", "skip"].includes(target)) {
+                    migrateChoice = target as "dev" | "remote" | "skip";
+                } else {
+                    fatal("migrate-target must be 'dev', 'remote', or 'skip'");
+                }
+            } else {
+                migrateChoice = "skip"; // Default in non-interactive mode
+            }
+        } else {
+            // Interactive mode - ask user
+            migrateChoice = (await (select as any)({
+                message: "Apply D1 migrations?",
+                options: [
+                    { value: "dev", label: "Yes, apply locally (dev)" },
+                    { value: "remote", label: "Yes, apply to remote (prod)" },
+                    { value: "skip", label: "No, skip migration" },
+                ],
+                initialValue: "skip",
+            })) as "dev" | "remote" | "skip";
+        }
+
+        if (migrateChoice === "dev") {
+            const migSpinner = spinner();
+            migSpinner.start("Applying migrations locally...");
+            const migRes = runScript(pm, "db:migrate:dev", process.cwd());
+            if (migRes.code === 0) {
+                migSpinner.stop(pc.green("Migrations applied locally."));
+            } else {
+                migSpinner.stop(pc.red("Failed to apply local migrations."));
+                assertOk(migRes, "Local migration failed.");
+            }
+        } else if (migrateChoice === "remote") {
+            const migSpinner = spinner();
+            migSpinner.start("Applying migrations to remote...");
+            const migRes = runScript(pm, "db:migrate:prod", process.cwd());
+            if (migRes.code === 0) {
+                migSpinner.stop(pc.green("Migrations applied to remote."));
+            } else {
+                migSpinner.stop(pc.red("Failed to apply remote migrations."));
+                assertOk(migRes, "Remote migration failed.");
+            }
+        }
+    } else {
+        // For non-D1 databases, just show a message
+        outro(
+            pc.yellow(
+                `Database type is ${database}. Please apply migrations to your database using your preferred workflow.`
+            )
+        );
+        return;
+    }
+
+    outro(pc.green("Migration completed successfully!"));
+}
+
+async function generate(cliArgs?: CliArgs) {
+    intro(`${pc.bold("Better Auth Cloudflare")} ${pc.gray("· generator")}`);
+
+    let answers: GenerateAnswers;
+
+    if (cliArgs && Object.keys(cliArgs).length > 0) {
+        // Non-interactive mode - use CLI arguments
+        const validationErrors = validateCliArgs(cliArgs);
+        if (validationErrors.length > 0) {
+            fatal("Invalid arguments:\n" + validationErrors.map(e => `  - ${e}`).join("\n"));
+        }
+
+        const partialAnswers = cliArgsToAnswers(cliArgs);
+
+        // Fill in required fields with defaults if not provided
+        answers = {
+            appName: partialAnswers.appName || "my-app",
+            template: partialAnswers.template || "hono",
+            database: partialAnswers.database || "d1",
+            geolocation: partialAnswers.geolocation !== undefined ? partialAnswers.geolocation : true,
+            kv: partialAnswers.kv !== undefined ? partialAnswers.kv : true,
+            r2: partialAnswers.r2 !== undefined ? partialAnswers.r2 : false,
+            // D1 defaults
+            d1Name:
+                partialAnswers.d1Name ||
+                (partialAnswers.database === "d1" ? `${partialAnswers.appName || "my-app"}-db` : undefined),
+            d1Binding: partialAnswers.d1Binding || (partialAnswers.database === "d1" ? "DATABASE" : undefined),
+            // Hyperdrive defaults
+            hdBinding: partialAnswers.hdBinding || (partialAnswers.database !== "d1" ? "HYPERDRIVE" : undefined),
+            hdName:
+                partialAnswers.hdName ||
+                (partialAnswers.database !== "d1" ? `${partialAnswers.appName || "my-app"}-hyperdrive` : undefined),
+            hdConnectionString: partialAnswers.hdConnectionString,
+            // KV defaults
+            kvBinding: partialAnswers.kvBinding || (partialAnswers.kv !== false ? "KV" : undefined),
+            kvNamespaceName:
+                partialAnswers.kvNamespaceName ||
+                (partialAnswers.kv !== false ? `${partialAnswers.appName || "my-app"}-kv` : undefined),
+            // R2 defaults
+            r2Binding: partialAnswers.r2Binding || (partialAnswers.r2 ? "R2_BUCKET" : undefined),
+            r2BucketName:
+                partialAnswers.r2BucketName ||
+                (partialAnswers.r2 ? `${partialAnswers.appName || "my-app"}-files` : undefined),
+            // Cloudflare account configuration
+            accountId: partialAnswers.accountId,
+            skipCloudflareSetup:
+                partialAnswers.skipCloudflareSetup !== undefined ? partialAnswers.skipCloudflareSetup : false,
+            // Migration options
+            applyMigrations: partialAnswers.applyMigrations || "skip",
+        };
+
+        // Additional validation for required fields in non-interactive mode
+        if (answers.database !== "d1" && !answers.hdConnectionString) {
+            fatal("hd-connection-string is required when using hyperdrive databases");
+        }
+    } else {
+        // Interactive mode - use prompts
+        answers = await group<GenerateAnswers>(
+            {
+                appName: () =>
+                    text({
+                        message: "Project name",
+                        placeholder: "my-app",
+                        validate: (v: string) => (!v || v.trim().length === 0 ? "Please enter a name" : undefined),
+                    }) as Promise<string>,
+                template: () => {
+                    return (select as any)({
+                        message: "Choose a template",
+                        options: [
+                            { value: "hono", label: "Hono (Workers)" },
+                            { value: "nextjs", label: "OpenNext.js (Workers)" },
+                        ],
+                        initialValue: "hono",
+                    }) as Promise<"hono" | "nextjs">;
+                },
+                database: () => {
+                    return (select as any)({
+                        message: "Database",
+                        options: [
+                            { value: "d1", label: "Cloudflare D1 (SQLite)" },
+                            { value: "hyperdrive-postgres", label: "Hyperdrive (Postgres)" },
+                            { value: "hyperdrive-mysql", label: "Hyperdrive (MySQL)" },
+                        ],
+                        initialValue: "d1",
+                    }) as Promise<DbKind>;
+                },
+                d1Name: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.database === "d1"
+                        ? (text({
+                              message: "D1 database name",
+                              placeholder: `${(results.appName as string) || "my-app"}-db`,
+                              defaultValue: `${(results.appName as string) || "my-app"}-db`,
+                          }) as Promise<string>)
+                        : undefined,
+                d1Binding: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.database === "d1"
+                        ? (text({
+                              message: "D1 binding name",
+                              placeholder: "DATABASE",
+                              defaultValue: "DATABASE",
+                              validate: validateBindingName,
+                          }) as Promise<string>)
+                        : undefined,
+                hdBinding: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.database !== "d1"
+                        ? (text({
+                              message: "Hyperdrive binding name",
+                              placeholder: "HYPERDRIVE",
+                              defaultValue: "HYPERDRIVE",
+                              validate: validateBindingName,
+                          }) as Promise<string>)
+                        : undefined,
+                hdName: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.database !== "d1"
+                        ? (text({
+                              message: "Hyperdrive instance name",
+                              placeholder: `${(results.appName as string) || "my-app"}-hyperdrive`,
+                              defaultValue: `${(results.appName as string) || "my-app"}-hyperdrive`,
+                          }) as Promise<string>)
+                        : undefined,
+                hdConnectionString: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.database !== "d1"
+                        ? (text({
+                              message: "Origin database connection string",
+                              placeholder: "postgres://user:pass@host:5432/db OR mysql://user:pass@host:3306/db",
+                          }) as Promise<string>)
+                        : undefined,
+                geolocation: () =>
+                    confirm({ message: "Enable geolocation tracking?", initialValue: true }) as Promise<boolean>,
+                kv: () => confirm({ message: "Use KV as secondary storage?", initialValue: true }) as Promise<boolean>,
+                kvBinding: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.kv
+                        ? (text({
+                              message: "KV binding name",
+                              placeholder: "KV",
+                              defaultValue: "KV",
+                              validate: validateBindingName,
+                          }) as Promise<string>)
+                        : undefined,
+                kvNamespaceName: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.kv
+                        ? (text({
+                              message: "KV namespace (Cloudflare) name",
+                              placeholder: `${(results.appName as string) || "my-app"}-kv`,
+                              defaultValue: `${(results.appName as string) || "my-app"}-kv`,
+                          }) as Promise<string>)
+                        : undefined,
+                r2: () => confirm({ message: "Enable R2 file storage?", initialValue: false }) as Promise<boolean>,
+                r2Binding: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.r2
+                        ? (text({
+                              message: "R2 binding name",
+                              placeholder: "R2_BUCKET",
+                              defaultValue: "R2_BUCKET",
+                              validate: validateBindingName,
+                          }) as Promise<string>)
+                        : undefined,
+                r2BucketName: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.r2
+                        ? (text({
+                              message: "R2 bucket name",
+                              placeholder: `${(results.appName as string) || "my-app"}-files`,
+                              defaultValue: `${(results.appName as string) || "my-app"}-files`,
+                          }) as Promise<string>)
+                        : undefined,
+            },
+            {
+                onCancel: () => {
+                    cancel("Operation cancelled.");
+                    process.exit(0);
+                },
+            }
+        );
+    }
+
+    const s = spinner();
+
+    const tmp = mkdtempSync(join(tmpdir(), "bacf-"));
+    s.start("Cloning templates...");
+    {
+        const res = bunSpawnSync("git", [
+            "clone",
+            "--depth",
+            "1",
+            "https://github.com/zpg6/better-auth-cloudflare.git",
+            tmp,
+        ]);
+        if (res.code === 0) s.stop("Templates ready.");
+        else {
+            s.stop("Failed to fetch templates.");
+            assertOk(res, "Failed to clone repository. Please ensure git is installed.");
+        }
+    }
+
+    const templateDir = answers.template === "hono" ? join(tmp, "examples/hono") : join(tmp, "examples/opennextjs");
+
+    const targetDir = resolve(process.cwd(), answers.appName);
+    try {
+        ensureCleanAppDir(targetDir);
+    } catch (err) {
+        fatal((err as Error).message);
+    }
+
+    const copying = spinner();
+    copying.start("Copying project files...");
+    try {
+        cpSync(templateDir, targetDir, { recursive: true });
+    } catch (e) {
+        copying.stop("Copy failed.");
+        fatal("Failed to copy template files.");
+    }
+    copying.stop("Project files copied.");
+
+    // Centralize project constants for future tooling
+    const constantsFile = join(targetDir, "project.config.json");
+    try {
+        writeFileSync(
+            constantsFile,
+            JSON.stringify(
+                {
+                    name: answers.appName,
+                    template: answers.template,
+                    database: answers.database,
+                    d1Name: answers.d1Name ?? null,
+                    d1Binding: answers.d1Binding ?? null,
+                    hdName: answers.hdName ?? null,
+                    hdBinding: answers.hdBinding ?? null,
+                    hdConnectionString: answers.hdConnectionString ?? null,
+                    geolocation: answers.geolocation,
+                    kv: answers.kv,
+                    kvBinding: answers.kvBinding ?? null,
+                    kvNamespaceName: answers.kvNamespaceName ?? null,
+                    r2: answers.r2,
+                    r2Binding: answers.r2Binding ?? null,
+                    r2BucketName: answers.r2BucketName ?? null,
+                },
+                null,
+                2
+            )
+        );
+    } catch (e) {
+        fatal("Failed to write project config.");
+    }
+
+    // Update package.json name and dependencies and scripts to use chosen bindings
+    const pkgPath = join(targetDir, "package.json");
+    if (existsSync(pkgPath)) {
+        try {
+            updateJSON(pkgPath, j => {
+                const deps = ((j.dependencies as JSONObject) || {}) as JSONObject;
+                if (typeof deps["better-auth-cloudflare"] === "string") {
+                    deps["better-auth-cloudflare"] = "latest";
+                }
+                if (answers.database === "hyperdrive-postgres") {
+                    deps["postgres"] = deps["postgres"] || "^3.4.5";
+                }
+                if (answers.database === "hyperdrive-mysql") {
+                    deps["mysql2"] = deps["mysql2"] || "^3.9.7";
+                }
+                const scripts = (j.scripts as JSONObject) || {};
+                for (const key of Object.keys(scripts)) {
+                    const val = String(scripts[key] as string);
+                    if (answers.database === "d1" && answers.d1Binding) {
+                        scripts[key] = val.replace(/wrangler\s+d1\s+migrations\s+apply\s+\w+/g, m =>
+                            m.replace(/apply\s+\w+/, `apply ${answers.d1Binding}`)
+                        ) as unknown as JSONValue;
+                    }
+                }
+                return { ...j, name: answers.appName, dependencies: deps, scripts } as JSONObject;
+            });
+        } catch (e) {
+            fatal("Failed to update package.json.");
+        }
+    }
+
+    // Update wrangler.toml bindings and names
+    const wranglerPath = join(targetDir, "wrangler.toml");
+    if (existsSync(wranglerPath)) {
+        try {
+            let wrangler = readFileSync(wranglerPath, "utf8");
+
+            if (answers.database === "d1" && answers.d1Name && answers.d1Binding) {
+                wrangler = updateD1Block(wrangler, answers.d1Binding, answers.d1Name);
+            }
+
+            // Clear template KV blocks and add user's configuration
+            if (answers.kv && answers.kvBinding) {
+                wrangler = clearAllKvBlocks(wrangler);
+                wrangler = appendOrReplaceKvNamespaceBlock(wrangler, answers.kvBinding);
+            } else {
+                // If user doesn't want KV, remove all KV blocks from template
+                wrangler = clearAllKvBlocks(wrangler);
+            }
+
+            // Clear template R2 blocks and add user's configuration
+            if (answers.r2 && answers.r2BucketName) {
+                const r2Binding = answers.r2Binding || "R2_BUCKET";
+                wrangler = clearAllR2Blocks(wrangler);
+                wrangler = appendOrReplaceR2Block(wrangler, r2Binding, answers.r2BucketName);
+            } else {
+                // If user doesn't want R2, remove all R2 blocks from template
+                wrangler = clearAllR2Blocks(wrangler);
+            }
+
+            writeFileSync(wranglerPath, wrangler);
+        } catch (e) {
+            fatal("Failed to update wrangler.toml.");
+        }
+    }
+
+    // Tweak example source based on options
+    const isHono = answers.template === "hono";
+    const isNext = answers.template === "nextjs";
+
+    try {
+        if (isHono) {
+            const authPath = join(targetDir, "src/auth/index.ts");
+            tryUpdateFile(authPath, code => {
+                let updated = code;
+                if (answers.database === "d1" && answers.d1Binding) {
+                    updated = updated.replace(/env\.DATABASE\b/g, `env.${answers.d1Binding}`);
+                    updated = updated.replace(
+                        /geolocationTracking:\s*true/g,
+                        `geolocationTracking: ${String(answers.geolocation)}`
+                    );
+                } else if (answers.database === "hyperdrive-postgres" && answers.hdBinding) {
+                    updated = updated.replace(/import\s+\{\s*drizzle\s*\}\s*from\s*"drizzle-orm\/d1";?/g, "");
+                    if (!/from\s+"drizzle-orm\/postgres-js"/.test(updated)) {
+                        updated =
+                            `import { drizzle } from "drizzle-orm/postgres-js";\nimport postgres from "postgres";\n` +
+                            updated;
+                    }
+                    updated = updated.replace(
+                        /const\s+db\s*=\s*env\s*\?\s*drizzle\([^\)]*\)\s*:\s*\(\{\}\s+as\s+any\)\s*;/,
+                        `const db = env ? drizzle(postgres(env.${answers.hdBinding}.connectionString), { schema, logger: true }) : ({} as any);`
+                    );
+                    updated = updated.replace(/d1:\s*env[^}]+}\s*,?/m, `postgres: { db },`);
+                    updated = updated.replace(
+                        /geolocationTracking:\s*true/g,
+                        `geolocationTracking: ${String(answers.geolocation)}`
+                    );
+                } else if (answers.database === "hyperdrive-mysql" && answers.hdBinding) {
+                    updated = updated.replace(/import\s+\{\s*drizzle\s*\}\s*from\s*"drizzle-orm\/d1";?/g, "");
+                    if (!/from\s+"drizzle-orm\/mysql2"/.test(updated)) {
+                        updated =
+                            `import { drizzle } from "drizzle-orm/mysql2";\nimport mysql from "mysql2/promise";\n` +
+                            updated;
+                    }
+                    updated = updated.replace(
+                        /const\s+db\s*=\s*env\s*\?\s*drizzle\([^\)]*\)\s*:\s*\(\{\}\s+as\s+any\)\s*;/,
+                        `const db = env ? drizzle(mysql.createPool(env.${answers.hdBinding}.connectionString), { schema }) : ({} as any);`
+                    );
+                    updated = updated.replace(/d1:\s*env[^}]+}\s*,?/m, `mysql: { db },`);
+                    updated = updated.replace(
+                        /geolocationTracking:\s*true/g,
+                        `geolocationTracking: ${String(answers.geolocation)}`
+                    );
+                }
+                if (answers.kv && answers.kvBinding) {
+                    updated = updated.replace(/kv:\s*env\?\.KV/g, `kv: env?.${answers.kvBinding}`);
+                } else {
+                    updated = updated.replace(/kv:\s*env\?\.[A-Z_]+,?/g, "");
+                }
+                if (answers.r2 && answers.r2Binding) {
+                    updated = updated.replace(/env\.R2_BUCKET\b/g, `env.${answers.r2Binding}`);
+                }
+                return updated;
+            });
+
+            const envPath = join(targetDir, "src/env.d.ts");
+            tryUpdateFile(envPath, code => {
+                let next = code;
+                if (answers.database === "d1" && answers.d1Binding) {
+                    next = next.replace(/DATABASE:\s*D1Database;/g, `${answers.d1Binding}: D1Database;`);
+                }
+                if (answers.database !== "d1" && answers.hdBinding) {
+                    if (new RegExp(`${answers.hdBinding}:`).test(next) === false) {
+                        next = next.replace(
+                            /\}\n\n?declare\s+global[\s\S]*/m,
+                            `${answers.hdBinding}: any;\n}\n\ndeclare global {\n    namespace NodeJS {\n        interface ProcessEnv extends CloudflareBindings {\n        }\n    }\n}`
+                        );
+                    }
+                }
+                if (answers.kv && answers.kvBinding) {
+                    next = next.replace(/KV:\s*KVNamespace[^;]*;/g, `${answers.kvBinding}: KVNamespace;`);
+                }
+                if (answers.r2 && answers.r2Binding) {
+                    if (/R2_BUCKET:\s*R2Bucket;/.test(next)) {
+                        next = next.replace(/R2_BUCKET:\s*R2Bucket;/g, `${answers.r2Binding}: R2Bucket;`);
+                    }
+                }
+                return next;
+            });
+
+            const drizzleCfg = join(targetDir, "drizzle.config.ts");
+            tryUpdateFile(drizzleCfg, code => {
+                if (answers.database === "hyperdrive-postgres") {
+                    return code
+                        .replace(/dialect:\s*"sqlite"/g, 'dialect: "postgresql"')
+                        .replace(/driver:\s*"d1-http"[\s\S]*?\},/g, "");
+                }
+                if (answers.database === "hyperdrive-mysql") {
+                    return code
+                        .replace(/dialect:\s*"sqlite"/g, 'dialect: "mysql2"')
+                        .replace(/driver:\s*"d1-http"[\s\S]*?\},/g, "");
+                }
+                return code;
+            });
+        }
+
+        if (isNext) {
+            const dbIndex = join(targetDir, "src/db/index.ts");
+            tryUpdateFile(dbIndex, code => {
+                if (answers.database === "d1" && answers.d1Binding) {
+                    return code.replace(/env\.DATABASE\b/g, `env.${answers.d1Binding}`);
+                }
+                if (answers.database === "hyperdrive-postgres" && answers.hdBinding) {
+                    let updated = code;
+                    updated = updated.replace(
+                        /import\s+\{\s*drizzle\s*\}\s*from\s*"drizzle-orm\/d1";?/g,
+                        'import { drizzle } from "drizzle-orm/postgres-js";'
+                    );
+                    if (!/from\s+"postgres"/.test(updated)) {
+                        updated = `import postgres from "postgres";\n` + updated;
+                    }
+                    updated = updated.replace(
+                        /return\s+drizzle\(env\.[^)]+\)\s*,?\s*\{[\s\S]*?\}\);/m,
+                        `return drizzle(postgres(env.${answers.hdBinding}.connectionString), {\n        schema,\n        logger: true,\n    });`
+                    );
+                    return updated;
+                }
+                if (answers.database === "hyperdrive-mysql" && answers.hdBinding) {
+                    let updated = code;
+                    updated = updated.replace(
+                        /import\s+\{\s*drizzle\s*\}\s*from\s*"drizzle-orm\/d1";?/g,
+                        'import { drizzle } from "drizzle-orm/mysql2";'
+                    );
+                    if (!/from\s+"mysql2\/promise"/.test(updated)) {
+                        updated = `import mysql from "mysql2/promise";\n` + updated;
+                    }
+                    updated = updated.replace(
+                        /return\s+drizzle\(env\.[^)]+\)\s*,?\s*\{[\s\S]*?\}\);/m,
+                        `const pool = await mysql.createPool(env.${answers.hdBinding}.connectionString);\n    return drizzle(pool, {\n        schema,\n    });`
+                    );
+                    return updated;
+                }
+                return code;
+            });
+
+            const nextAuth = join(targetDir, "src/auth/index.ts");
+            tryUpdateFile(nextAuth, code => {
+                let updated = code;
+                if (answers.database === "hyperdrive-postgres") {
+                    updated = updated.replace(
+                        /d1:\s*\{[\s\S]*?\},/m,
+                        `postgres: {\n                    db: dbInstance,\n                },`
+                    );
+                }
+                if (answers.database === "hyperdrive-mysql") {
+                    updated = updated.replace(
+                        /d1:\s*\{[\s\S]*?\},/m,
+                        `mysql: {\n                    db: dbInstance,\n                },`
+                    );
+                }
+                if (answers.kv && answers.kvBinding) {
+                    updated = updated.replace(/process\.env\.KV\b/g, `process.env.${answers.kvBinding}`);
+                } else {
+                    updated = updated.replace(/\n\s*kv:\s*process\.env\.[A-Z_]+[^\n]*,?/g, "\n");
+                }
+                if (answers.r2 && answers.r2Binding) {
+                    updated = updated.replace(
+                        /getCloudflareContext\(\)\.env\.R2_BUCKET\b/g,
+                        `getCloudflareContext().env.${answers.r2Binding}`
+                    );
+                }
+                return updated;
+            });
+
+            const envPath = join(targetDir, "env.d.ts");
+            tryUpdateFile(envPath, code => {
+                let next = code;
+                if (answers.database === "d1" && answers.d1Binding) {
+                    next = next.replace(/DATABASE:\s*D1Database;/g, `${answers.d1Binding}: D1Database;`);
+                }
+                if (answers.database !== "d1" && answers.hdBinding) {
+                    if (/HYPERDRIVE:/.test(next)) {
+                        next = next.replace(/HYPERDRIVE:\s*.+;/g, `${answers.hdBinding}: any;`);
+                    } else {
+                        next = next.replace(/\}\s*$/m, `    ${answers.hdBinding}: any;\n}`);
+                    }
+                }
+                if (answers.kv && answers.kvBinding) {
+                    next = next.replace(/KV:\s*KVNamespace<[^>]+>;/g, `${answers.kvBinding}: KVNamespace<string>;`);
+                }
+                if (answers.r2 && answers.r2Binding) {
+                    next = next.replace(/R2_BUCKET:\s*R2Bucket;/g, `${answers.r2Binding}: R2Bucket;`);
+                }
+                return next;
+            });
+
+            const drizzleCfg = join(targetDir, "drizzle.config.ts");
+            tryUpdateFile(drizzleCfg, code => {
+                if (answers.database === "hyperdrive-postgres") {
+                    return code
+                        .replace(/dialect:\s*"sqlite"/g, 'dialect: "postgresql"')
+                        .replace(/driver:\s*"d1-http"[\s\S]*?\},/g, "");
+                }
+                if (answers.database === "hyperdrive-mysql") {
+                    return code
+                        .replace(/dialect:\s*"sqlite"/g, 'dialect: "mysql2"')
+                        .replace(/driver:\s*"d1-http"[\s\S]*?\},/g, "");
+                }
+                return code;
+            });
+        }
+    } catch (e) {
+        fatal("Failed to update template source files.");
+    }
+
+    // Append subtle footer
+    try {
+        const readmePath = join(targetDir, "README.md");
+        const footer = `\n\n—\nPowered by better-auth-cloudflare`;
+        if (existsSync(readmePath)) {
+            const current = readFileSync(readmePath, "utf8");
+            if (!current.includes("Powered by better-auth-cloudflare")) {
+                writeFileSync(readmePath, current.trimEnd() + footer);
+            }
+        }
+    } catch (e) {
+        fatal("Failed to update README.");
+    }
+
+    // Handle Cloudflare setup
+    const isNonInteractive = Boolean(cliArgs && Object.keys(cliArgs).length > 0);
+    let setup: boolean;
+
+    if (isNonInteractive) {
+        // Non-interactive mode
+        setup = !answers.skipCloudflareSetup;
+        if (answers.skipCloudflareSetup) {
+            outro(pc.yellow("Skipping Cloudflare setup as requested."));
+        }
+    } else {
+        // Interactive mode
+        const confirmResult = await confirm({ message: "Run Cloudflare setup commands now?" });
+        setup = confirmResult === true;
+        if (!setup) {
+            outro(pc.yellow("You can run wrangler setup later."));
+        }
+    }
+
+    if (setup) {
+        // Ensure user is authenticated and handle account selection
+        const authResult = await ensureWranglerAuth(isNonInteractive);
+        if (authResult === "skip-setup") {
+            setup = false;
+        }
+    }
+
+    if (setup) {
+        const cwd = targetDir;
+
+        if (answers.database === "d1" && answers.d1Name) {
+            const creating = spinner();
+            creating.start(`Creating D1 Database \`${answers.d1Name}\`...`);
+            const res = runWranglerCommand(["d1", "create", answers.d1Name], cwd, answers.accountId);
+
+            if (res.code === 0) {
+                creating.stop(pc.green(`\`${answers.d1Name}\` created.`));
+            } else if (
+                res.stderr.includes("More than one account available but unable to select one in non-interactive mode")
+            ) {
+                creating.stop(pc.red("Failed to create D1 database."));
+                const selectedAccountId = await handleAccountSelection(res.stderr, isNonInteractive);
+                if (selectedAccountId) {
+                    // Retry with selected account
+                    creating.start(`Creating D1 Database \`${answers.d1Name}\`...`);
+                    const retryRes = runWranglerCommand(["d1", "create", answers.d1Name], cwd, selectedAccountId);
+                    if (retryRes.code === 0) {
+                        creating.stop(pc.green(`\`${answers.d1Name}\` created.`));
+                        answers.accountId = selectedAccountId; // Save for subsequent commands
+                    } else {
+                        creating.stop(pc.red("Failed to create D1 database."));
+                        assertOk(retryRes, "D1 creation failed.");
+                    }
+                }
+            } else {
+                creating.stop(pc.red("Failed to create D1 database."));
+                assertOk(res, "D1 creation failed.");
+            }
+        }
+
+        if (answers.database !== "d1" && answers.hdName && answers.hdConnectionString && answers.hdBinding) {
+            const creating = spinner();
+            creating.start(`Creating Hyperdrive \`${answers.hdName}\`...`);
+            const res = runWranglerCommand(
+                ["hyperdrive", "create", answers.hdName, `--connection-string=${answers.hdConnectionString}`],
+                cwd,
+                answers.accountId
+            );
+            if (res.code === 0) {
+                const match = /id:\s*([a-f0-9-]+)/i.exec(res.stdout);
+                const id = match ? match[1] : undefined;
+                if (id && existsSync(wranglerPath)) {
+                    let wrangler = readFileSync(wranglerPath, "utf8");
+                    wrangler = appendOrReplaceHyperdriveBlock(wrangler, answers.hdBinding, id);
+                    writeFileSync(wranglerPath, wrangler);
+                }
+                creating.stop(pc.green(`Hyperdrive created${id ? " (id: " + id + ")" : ""}.`));
+            } else {
+                creating.stop(pc.red("Failed to create Hyperdrive."));
+                assertOk(res, "Hyperdrive creation failed.");
+            }
+        }
+
+        if (answers.kv && answers.kvNamespaceName && answers.kvBinding) {
+            const creating = spinner();
+            creating.start(`Creating KV Namespace \`${answers.kvNamespaceName}\`...`);
+            const res = runWranglerCommand(["kv:namespace", "create", answers.kvNamespaceName], cwd, answers.accountId);
+            if (res.code === 0) {
+                const match = /id:\s*([a-f0-9-]+)/i.exec(res.stdout);
+                const id = match ? match[1] : undefined;
+                if (existsSync(wranglerPath)) {
+                    let wrangler = readFileSync(wranglerPath, "utf8");
+                    wrangler = appendOrReplaceKvNamespaceBlock(wrangler, answers.kvBinding, id);
+                    writeFileSync(wranglerPath, wrangler);
+                }
+                creating.stop(pc.green(`KV namespace created${id ? " (id: " + id + ")" : ""}.`));
+            } else {
+                creating.stop(pc.red("Failed to create KV namespace."));
+                assertOk(res, "KV namespace creation failed.");
+            }
+        }
+
+        if (answers.r2 && answers.r2BucketName) {
+            const creating = spinner();
+            const r2Binding = answers.r2Binding || "R2_BUCKET";
+            creating.start(`Creating R2 Bucket \`${answers.r2BucketName}\`...`);
+            const res = runWranglerCommand(["r2", "bucket", "create", answers.r2BucketName], cwd, answers.accountId);
+            if (res.code === 0) {
+                if (existsSync(wranglerPath)) {
+                    let wrangler = readFileSync(wranglerPath, "utf8");
+                    wrangler = appendOrReplaceR2Block(wrangler, r2Binding, answers.r2BucketName);
+                    writeFileSync(wranglerPath, wrangler);
+                }
+                creating.stop(pc.green(`\`${answers.r2BucketName}\` created.`));
+            } else {
+                creating.stop(pc.red("Failed to create R2 bucket."));
+                assertOk(res, "R2 bucket creation failed.");
+            }
+        }
+    }
+
+    // Install deps before running scripts
+    const pm = detectPackageManager(targetDir);
+    let doInstall: boolean;
+
+    if (isNonInteractive) {
+        // In non-interactive mode, always install dependencies
+        doInstall = true;
+    } else {
+        // In interactive mode, ask user
+        const installResult = await confirm({ message: "Install dependencies now?", initialValue: true });
+        doInstall = installResult === true;
+    }
+
+    if (doInstall) {
+        const inst = spinner();
+        inst.start("Installing dependencies...");
+        const res = runInstall(pm, targetDir);
+        if (res.code === 0) inst.stop(pc.green("Dependencies installed."));
+        else {
+            inst.stop(pc.red("Failed to install dependencies."));
+            assertOk(res, "Dependency installation failed.");
+        }
+    }
+
+    // Schema generation & migrations
+    const genAuth = spinner();
+    genAuth.start("Generating auth schema...");
+    {
+        const authRes = runScript(pm, "auth:update", targetDir);
+        if (authRes.code === 0) genAuth.stop(pc.green("Auth schema updated."));
+        else {
+            genAuth.stop(pc.red("Failed to generate auth schema."));
+            assertOk(authRes, "Auth schema generation failed.");
+        }
+    }
+
+    const genDb = spinner();
+    genDb.start("Generating Drizzle migrations...");
+    {
+        const dbGenRes = runScript(pm, "db:generate", targetDir);
+        if (dbGenRes.code === 0) genDb.stop(pc.green("Drizzle migrations generated."));
+        else {
+            genDb.stop(pc.red("Failed to generate migrations."));
+            assertOk(dbGenRes, "Migration generation failed.");
+        }
+    }
+
+    if (answers.database === "d1" && !answers.skipCloudflareSetup) {
+        let migrateChoice: "dev" | "prod" | "skip";
+
+        if (isNonInteractive) {
+            // In non-interactive mode, use the CLI argument or default to skip
+            migrateChoice = answers.applyMigrations || "skip";
+        } else {
+            // In interactive mode, ask user
+            migrateChoice = (await (select as any)({
+                message: "Apply D1 migrations now?",
+                options: [
+                    { value: "dev", label: "Yes, apply locally (wrangler d1 --local)" },
+                    { value: "prod", label: "Yes, apply to remote (wrangler d1 --remote)" },
+                    { value: "skip", label: "No, I'll do it later" },
+                ],
+                initialValue: "skip",
+            })) as "dev" | "prod" | "skip";
+        }
+
+        if (migrateChoice === "dev") {
+            const mig = spinner();
+            mig.start("Applying migrations locally...");
+            const res = runScript(pm, "db:migrate:dev", targetDir);
+            if (res.code === 0) mig.stop(pc.green("Migrations applied locally."));
+            else {
+                mig.stop(pc.red("Failed to apply local migrations."));
+                assertOk(res, "Local migration failed.");
+            }
+        } else if (migrateChoice === "prod") {
+            const mig = spinner();
+            mig.start("Applying migrations remotely...");
+            const res = runScript(pm, "db:migrate:prod", targetDir);
+            if (res.code === 0) mig.stop(pc.green("Migrations applied remotely."));
+            else {
+                mig.stop(pc.red("Failed to apply remote migrations."));
+                assertOk(res, "Remote migration failed.");
+            }
+        }
+    }
+
+    // Final instructions
+    const pmDev = pm === "yarn" ? "yarn dev" : pm === "npm" ? "npm run dev" : `${pm} run dev`;
+    const runScriptHelp = (name: string) =>
+        pm === "yarn" ? `yarn ${name}` : pm === "npm" ? `npm run ${name}` : `${pm} run ${name}`;
+
+    const lines: string[] = [];
+    lines.push(`${pc.green("✔")} ${pc.bold("Project created!")}`);
+    lines.push(`  ${pc.cyan("cd")} ${answers.appName}`);
+    lines.push(`  ${pc.cyan(pmDev)}  ${pc.gray("# Start dev server")}`);
+    lines.push("");
+    lines.push(pc.bold("Common scripts:"));
+    lines.push(`  ${runScriptHelp("auth:update")}   ${pc.gray("# Generate Better Auth schema")}`);
+    lines.push(`  ${runScriptHelp("db:generate")}   ${pc.gray("# Create Drizzle migrations")}`);
+    if (answers.database === "d1") {
+        lines.push(`  ${runScriptHelp("db:migrate:dev")} ${pc.gray("# Apply migrations locally (D1)")}`);
+        lines.push(`  ${runScriptHelp("db:migrate:prod")} ${pc.gray("# Apply migrations to remote (D1)")}`);
+    } else {
+        lines.push(
+            pc.gray(
+                "Apply migrations to your Postgres/MySQL database using your preferred workflow (Drizzle Kit push/migrate)."
+            )
+        );
+    }
+    lines.push(`  ${runScriptHelp("db:studio:dev")} ${pc.gray("# Open Drizzle Studio (local)")}`);
+    lines.push(`  ${runScriptHelp("db:studio:prod")} ${pc.gray("# Open Drizzle Studio (remote)")}`);
+    lines.push("");
+    lines.push(pc.gray("Refer to the example README for more details and deployment commands."));
+
+    outro(lines.join("\n"));
+}
+
+function printHelp() {
+    const help =
+        `\n${pc.bold("@better-auth-cloudflare/cli")}\n\n` +
+        `Usage:\n` +
+        `  npx @better-auth-cloudflare/cli                         Run interactive generator\n` +
+        `  npx @better-auth-cloudflare/cli generate                Run interactive generator\n` +
+        `  npx @better-auth-cloudflare/cli migrate                 Run migration workflow\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=my-app ...   Run with arguments\n` +
+        `  bunx @better-auth-cloudflare/cli --app-name=my-app ...  Run with arguments\n` +
+        `\n` +
+        `Arguments:\n` +
+        `  --app-name=<name>              Project name (default: my-app)\n` +
+        `  --template=<template>          hono | nextjs (default: hono)\n` +
+        `  --database=<db>                d1 | hyperdrive-postgres | hyperdrive-mysql (default: d1)\n` +
+        `  --geolocation=<bool>           Enable geolocation tracking (default: true)\n` +
+        `  --kv=<bool>                    Use KV storage (default: true)\n` +
+        `  --r2=<bool>                    Enable R2 storage (default: false)\n` +
+        `\n` +
+        `Database-specific arguments:\n` +
+        `  --d1-name=<name>               D1 database name (default: <app-name>-db)\n` +
+        `  --d1-binding=<binding>         D1 binding name (default: DATABASE)\n` +
+        `  --hd-name=<name>               Hyperdrive instance name (default: <app-name>-hyperdrive)\n` +
+        `  --hd-binding=<binding>         Hyperdrive binding name (default: HYPERDRIVE)\n` +
+        `  --hd-connection-string=<url>   Database connection string (required for hyperdrive)\n` +
+        `\n` +
+        `Storage arguments:\n` +
+        `  --kv-binding=<binding>         KV binding name (default: KV)\n` +
+        `  --kv-namespace-name=<name>     KV namespace name (default: <app-name>-kv)\n` +
+        `  --r2-binding=<binding>         R2 binding name (default: R2_BUCKET)\n` +
+        `  --r2-bucket-name=<name>        R2 bucket name (default: <app-name>-files)\n` +
+        `\n` +
+        `Cloudflare account arguments:\n` +
+        `  --account-id=<id>              Cloudflare account ID (for non-interactive mode)\n` +
+        `  --skip-cloudflare-setup=<bool> Skip Cloudflare resource creation (default: false)\n` +
+        `  --apply-migrations=<choice>    Apply D1 migrations: dev | prod | skip (default: skip)\n` +
+        `\n` +
+        `Migrate command arguments:\n` +
+        `  --migrate-target=<target>      For migrate command: dev | remote | skip (default: skip)\n` +
+        `\n` +
+        `Examples:\n` +
+        `  # Create a Hono app with D1 database\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=my-hono-app --template=hono --database=d1\n` +
+        `\n` +
+        `  # Create a Next.js app with PostgreSQL via Hyperdrive\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=my-next-app --template=nextjs \\\n` +
+        `    --database=hyperdrive-postgres --hd-connection-string=postgres://user:pass@host:5432/db\n` +
+        `\n` +
+        `  # Create app without KV or R2\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=minimal-app --kv=false --r2=false\n` +
+        `\n` +
+        `  # Skip Cloudflare setup (useful for CI/CD)\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=ci-app --skip-cloudflare-setup=true\n` +
+        `\n` +
+        `  # Specify account ID for non-interactive mode\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=prod-app --account-id=your-account-id\n` +
+        `\n` +
+        `  # Apply migrations automatically in non-interactive mode\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=auto-app --apply-migrations=dev\n` +
+        `\n` +
+        `  # Run migration workflow interactively\n` +
+        `  npx @better-auth-cloudflare/cli migrate\n` +
+        `\n` +
+        `  # Run migration workflow with non-interactive target\n` +
+        `  npx @better-auth-cloudflare/cli migrate --migrate-target=dev\n` +
+        `\n` +
+        `Creates a new Better Auth Cloudflare project from Hono or OpenNext.js templates,\n` +
+        `optionally creating Cloudflare D1, KV, R2, or Hyperdrive resources for you.\n` +
+        `The migrate command runs auth:update, db:generate, and optionally db:migrate.\n`;
+    // eslint-disable-next-line no-console
+    console.log(help);
+}
+
+const cmd = process.argv[2];
+
+// Check for help first
+if (cmd === "help" || cmd === "-h" || cmd === "--help") {
+    printHelp();
+} else if (cmd === "migrate") {
+    // Handle migrate command
+    const hasCliArgs = process.argv.slice(3).some(arg => arg.startsWith("--"));
+    const cliArgs = hasCliArgs ? parseCliArgs(process.argv) : undefined;
+    migrate(cliArgs).catch(err => {
+        fatal(String(err?.message ?? err));
+    });
+} else {
+    // Check if we have CLI arguments (starts with --)
+    const hasCliArgs = process.argv.slice(2).some(arg => arg.startsWith("--"));
+
+    if (!cmd || cmd === "generate" || hasCliArgs) {
+        const cliArgs = hasCliArgs ? parseCliArgs(process.argv) : undefined;
+        generate(cliArgs).catch(err => {
+            fatal(String(err?.message ?? err));
+        });
+    } else {
+        printHelp();
+        process.exit(1);
+    }
+}

--- a/cli/src/lib/helpers.ts
+++ b/cli/src/lib/helpers.ts
@@ -1,0 +1,79 @@
+export type JSONValue = string | number | boolean | null | JSONArray | JSONObject;
+export interface JSONObject {
+    [key: string]: JSONValue;
+}
+export interface JSONArray extends Array<JSONValue> {}
+
+export function validateBindingName(name: string): string | undefined {
+    if (!name || name.trim().length === 0) return "Please enter a binding name";
+    if (!/^[A-Z0-9_]+$/.test(name)) return "Use ONLY A-Z, 0-9, and underscores";
+    return undefined;
+}
+
+export function updateJSON(filePath: string, mutator: (json: JSONObject) => JSONObject) {
+    const { readFileSync, writeFileSync } = require("fs") as typeof import("fs");
+    const json = JSON.parse(readFileSync(filePath, "utf8")) as JSONObject;
+    const next = mutator(json);
+    writeFileSync(filePath, JSON.stringify(next, null, 2));
+}
+
+export function extractFirstBlock(toml: string, header: string) {
+    const re = new RegExp(`(\\[\\[${header}\\]\\][\\s\\S]*?)(?=\\n\\[\\[|$)`);
+    const match = re.exec(toml);
+    if (!match) return null;
+    return { block: match[1], start: match.index, end: match.index + match[1].length };
+}
+
+export function updateD1Block(toml: string, binding: string, dbName: string) {
+    const found = extractFirstBlock(toml, "d1_databases");
+    if (!found) return toml;
+    let block = found.block;
+    if (/binding\s*=\s*"[^"]+"/.test(block)) {
+        block = block.replace(/binding\s*=\s*"[^"]+"/, `binding = "${binding}"`);
+    } else {
+        block = block.replace(/\[\[d1_databases\]\]/, `[[d1_databases]]\nbinding = "${binding}"`);
+    }
+    if (/database_name\s*=\s*"[^"]+"/.test(block)) {
+        block = block.replace(/database_name\s*=\s*"[^"]+"/, `database_name = "${dbName}"`);
+    }
+    return toml.slice(0, found.start) + block + toml.slice(found.end);
+}
+
+export function appendOrReplaceKvNamespaceBlock(toml: string, binding: string, id?: string) {
+    const kvBlockRegex = /\[\[kv_namespaces\]\][\s\S]*?(?=(\n\[\[|$))/g;
+    const blocks = toml.match(kvBlockRegex) || [];
+    const newBlock = ["[[kv_namespaces]]", `binding = "${binding}"`, id ? `id = "${id}"` : ""]
+        .filter(Boolean)
+        .join("\n");
+
+    const existingIndex = blocks.findIndex(b => b.includes(`binding = "${binding}"`));
+    if (existingIndex >= 0) {
+        const existing = blocks[existingIndex];
+        return toml.replace(existing, newBlock);
+    }
+    return toml.trimEnd() + "\n\n" + newBlock + "\n";
+}
+
+export function appendOrReplaceR2Block(toml: string, binding: string, bucketName: string) {
+    const r2BlockRegex = /\[\[r2_buckets\]\][\s\S]*?(?=(\n\[\[|$))/g;
+    const blocks = toml.match(r2BlockRegex) || [];
+    const newBlock = ["[[r2_buckets]]", `binding = "${binding}"`, `bucket_name = "${bucketName}"`].join("\n");
+    const existingIndex = blocks.findIndex(b => b.includes(`binding = "${binding}"`));
+    if (existingIndex >= 0) {
+        const existing = blocks[existingIndex];
+        return toml.replace(existing, newBlock);
+    }
+    return toml.trimEnd() + "\n\n" + newBlock + "\n";
+}
+
+export function appendOrReplaceHyperdriveBlock(toml: string, binding: string, id: string) {
+    const blockRegex = /\[\[hyperdrive\]\][\s\S]*?(?=(\n\[\[|$))/g;
+    const blocks = toml.match(blockRegex) || [];
+    const newBlock = ["[[hyperdrive]]", `binding = "${binding}"`, `id = "${id}"`].join("\n");
+    const existingIndex = blocks.findIndex(b => b.includes(`binding = "${binding}"`));
+    if (existingIndex >= 0) {
+        const existing = blocks[existingIndex];
+        return toml.replace(existing, newBlock);
+    }
+    return toml.trimEnd() + "\n\n" + newBlock + "\n";
+}

--- a/cli/tests/cli-args.test.ts
+++ b/cli/tests/cli-args.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+describe("CLI Argument Handling", () => {
+    test("CLI supports expected commands", () => {
+        // Test that the CLI recognizes these commands
+        const validCommands = [
+            undefined, // no command defaults to generate
+            "generate",
+            "migrate",
+            "help",
+            "-h",
+            "--help",
+        ];
+
+        // This is a structural test to ensure our CLI handles these cases
+        // The actual CLI execution is tested through the main CLI functionality
+        expect(validCommands).toContain("generate");
+        expect(validCommands).toContain("migrate");
+        expect(validCommands).toContain("help");
+        expect(validCommands).toContain("-h");
+        expect(validCommands).toContain("--help");
+    });
+
+    test("CLI supports non-interactive argument mode", () => {
+        // Test that CLI arguments are recognized
+        const cliArgPatterns = [
+            "--app-name=value",
+            "--template=hono",
+            "--database=d1",
+            "--geolocation=true",
+            "--kv=false",
+            "--r2",
+            "--d1-binding=DATABASE",
+            "--hd-connection-string=postgres://host/db",
+            "--migrate-target=dev",
+            "--migrate-target=remote",
+            "--migrate-target=skip",
+        ];
+
+        // Test that all patterns start with -- (CLI argument format)
+        for (const pattern of cliArgPatterns) {
+            expect(pattern.startsWith("--")).toBe(true);
+        }
+    });
+
+    test("help text structure is defined", () => {
+        // Test the help text structure without executing the CLI
+        const expectedHelpElements = [
+            "@better-auth-cloudflare/cli",
+            "Usage:",
+            "npx @better-auth-cloudflare/cli",
+            "bunx @better-auth-cloudflare/cli",
+            "generate",
+            "migrate",
+            "Better Auth Cloudflare project",
+            "Hono or OpenNext.js templates",
+        ];
+
+        // Verify that all expected help elements are defined
+        for (const element of expectedHelpElements) {
+            expect(typeof element).toBe("string");
+            expect(element.length).toBeGreaterThan(0);
+        }
+    });
+
+    test("migrate command supports expected arguments", () => {
+        // Test migrate-specific CLI arguments
+        const migrateArguments = ["--migrate-target=dev", "--migrate-target=remote", "--migrate-target=skip"];
+
+        // All migrate arguments should follow the correct format
+        for (const arg of migrateArguments) {
+            expect(arg.startsWith("--migrate-target=")).toBe(true);
+            const value = arg.split("=")[1];
+            expect(["dev", "remote", "skip"]).toContain(value);
+        }
+    });
+
+    test("CLI command structure is valid", () => {
+        // Test the command parsing logic structure
+        const testArgv = ["node", "cli", "generate"];
+        const cmd = testArgv[2];
+
+        // Test the logic that determines which command to run
+        expect(cmd === "generate" || cmd === undefined).toBeTruthy();
+        expect(cmd === "help" || cmd === "-h" || cmd === "--help").toBeFalsy();
+    });
+
+    test("unknown command handling structure", () => {
+        const testArgv = ["node", "cli", "unknown"];
+        const cmd = testArgv[2];
+
+        // Test that unknown commands are not recognized as valid
+        const isValidCommand =
+            !cmd || cmd === "generate" || cmd === "migrate" || cmd === "help" || cmd === "-h" || cmd === "--help";
+        expect(isValidCommand).toBeFalsy();
+    });
+
+    test("CLI argument detection logic", () => {
+        // Test the logic that detects when CLI arguments are present
+        const scenarios = [
+            { argv: ["node", "cli"], hasArgs: false },
+            { argv: ["node", "cli", "generate"], hasArgs: false },
+            { argv: ["node", "cli", "--app-name=test"], hasArgs: true },
+            { argv: ["node", "cli", "generate", "--template=hono"], hasArgs: true },
+            { argv: ["node", "cli", "migrate"], hasArgs: false },
+            { argv: ["node", "cli", "migrate", "--migrate-target=dev"], hasArgs: true },
+            { argv: ["node", "cli", "help"], hasArgs: false },
+            { argv: ["node", "cli", "--help"], hasArgs: true },
+        ];
+
+        for (const scenario of scenarios) {
+            const hasCliArgs = scenario.argv.slice(2).some(arg => arg.startsWith("--"));
+            expect(hasCliArgs).toBe(scenario.hasArgs);
+        }
+    });
+
+    test("mixed command and argument handling", () => {
+        // Test how the CLI handles commands mixed with arguments
+        const testCases = [
+            {
+                argv: ["node", "cli", "--app-name=test"],
+                expectNonInteractive: true,
+                description: "CLI args without command should trigger non-interactive",
+            },
+            {
+                argv: ["node", "cli", "generate", "--app-name=test"],
+                expectNonInteractive: true,
+                description: "generate with CLI args should be non-interactive",
+            },
+            {
+                argv: ["node", "cli", "generate"],
+                expectNonInteractive: false,
+                description: "generate without CLI args should be interactive",
+            },
+        ];
+
+        for (const testCase of testCases) {
+            const cmd = testCase.argv[2];
+            const hasCliArgs = testCase.argv.slice(2).some(arg => arg.startsWith("--"));
+
+            // Logic from main CLI: if we have CLI args OR it's a generate/empty command
+            const shouldUseNonInteractive = hasCliArgs;
+            const shouldRunGenerate = !cmd || cmd === "generate" || hasCliArgs;
+
+            if (shouldRunGenerate) {
+                expect(shouldUseNonInteractive).toBe(testCase.expectNonInteractive);
+            }
+        }
+    });
+});

--- a/cli/tests/cli-combinations.test.ts
+++ b/cli/tests/cli-combinations.test.ts
@@ -1,0 +1,397 @@
+import { describe, expect, test } from "bun:test";
+import * as TOML from "@iarna/toml";
+import {
+    appendOrReplaceKvNamespaceBlock,
+    appendOrReplaceR2Block,
+    clearAllKvBlocks,
+    clearAllR2Blocks,
+    updateD1Block,
+} from "../src/index";
+
+// Base template TOML that represents what's copied from examples
+const baseTemplate = `# For more details on how to configure Wrangler, refer to:
+# https://developers.cloudflare.com/workers/wrangler/configuration/
+
+name = "better-auth-cloudflare"
+main = ".open-next/worker.js"
+compatibility_date = "2025-03-01"
+compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
+
+[assets]
+binding = "ASSETS"
+directory = ".open-next/assets"
+
+[observability]
+enabled = true
+
+[placement]
+mode = "smart"
+
+[[d1_databases]]
+binding = "DATABASE"
+database_name = "better-auth-cloudflare-db"
+database_id = "abd74206-37a2-4233-9813-cda1473be8f9"
+migrations_dir = "drizzle"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "cfa2f71dcfff43ffaab4c093968f6347"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "better-auth-cloudflare-files"
+`;
+
+describe("CLI Selection Combinations", () => {
+    test("D1 + KV + R2 with default bindings", () => {
+        let toml = baseTemplate;
+
+        // Simulate CLI processing with default bindings
+        toml = updateD1Block(toml, "DATABASE", "my-app-db");
+        toml = clearAllKvBlocks(toml);
+        toml = appendOrReplaceKvNamespaceBlock(toml, "KV", "kv-12345");
+        toml = clearAllR2Blocks(toml);
+        toml = appendOrReplaceR2Block(toml, "R2_BUCKET", "my-app-files");
+
+        // Verify all blocks exist and are valid
+        expect(toml).toContain('database_name = "my-app-db"');
+        expect(toml).toContain('binding = "DATABASE"');
+        expect(toml).toContain('binding = "KV"');
+        expect(toml).toContain('id = "kv-12345"');
+        expect(toml).toContain('binding = "R2_BUCKET"');
+        expect(toml).toContain('bucket_name = "my-app-files"');
+
+        // Ensure no duplicates
+        expect((toml.match(/\[\[d1_databases\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[kv_namespaces\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[r2_buckets\]\]/g) || []).length).toBe(1);
+    });
+
+    test("D1 + KV only (no R2)", () => {
+        let toml = baseTemplate;
+
+        // User chooses D1 + KV but no R2
+        toml = updateD1Block(toml, "DATABASE", "my-app-db");
+        toml = clearAllKvBlocks(toml);
+        toml = appendOrReplaceKvNamespaceBlock(toml, "KV", "kv-12345");
+        toml = clearAllR2Blocks(toml); // Remove R2 since user didn't want it
+
+        // Should have D1 and KV but no R2
+        expect(toml).toContain("[[d1_databases]]");
+        expect(toml).toContain("[[kv_namespaces]]");
+        expect(toml).not.toContain("[[r2_buckets]]");
+
+        expect((toml.match(/\[\[d1_databases\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[kv_namespaces\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[r2_buckets\]\]/g) || []).length).toBe(0);
+    });
+
+    test("D1 + R2 only (no KV)", () => {
+        let toml = baseTemplate;
+
+        // User chooses D1 + R2 but no KV
+        toml = updateD1Block(toml, "DATABASE", "my-app-db");
+        toml = clearAllKvBlocks(toml); // Remove KV since user didn't want it
+        toml = clearAllR2Blocks(toml);
+        toml = appendOrReplaceR2Block(toml, "R2_BUCKET", "my-app-files");
+
+        // Should have D1 and R2 but no KV
+        expect(toml).toContain("[[d1_databases]]");
+        expect(toml).toContain("[[r2_buckets]]");
+        expect(toml).not.toContain("[[kv_namespaces]]");
+
+        expect((toml.match(/\[\[d1_databases\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[kv_namespaces\]\]/g) || []).length).toBe(0);
+        expect((toml.match(/\[\[r2_buckets\]\]/g) || []).length).toBe(1);
+    });
+
+    test("D1 only (no KV, no R2)", () => {
+        let toml = baseTemplate;
+
+        // User chooses only D1
+        toml = updateD1Block(toml, "DATABASE", "my-app-db");
+        toml = clearAllKvBlocks(toml);
+        toml = clearAllR2Blocks(toml);
+
+        // Should have only D1
+        expect(toml).toContain("[[d1_databases]]");
+        expect(toml).not.toContain("[[kv_namespaces]]");
+        expect(toml).not.toContain("[[r2_buckets]]");
+
+        expect((toml.match(/\[\[d1_databases\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[kv_namespaces\]\]/g) || []).length).toBe(0);
+        expect((toml.match(/\[\[r2_buckets\]\]/g) || []).length).toBe(0);
+    });
+
+    test("Custom binding names", () => {
+        let toml = baseTemplate;
+
+        // User chooses custom binding names
+        toml = updateD1Block(toml, "MY_DATABASE", "custom-db");
+        toml = clearAllKvBlocks(toml);
+        toml = appendOrReplaceKvNamespaceBlock(toml, "MY_KV", "kv-12345");
+        toml = clearAllR2Blocks(toml);
+        toml = appendOrReplaceR2Block(toml, "MY_R2", "custom-files");
+
+        // Should have custom bindings
+        expect(toml).toContain('binding = "MY_DATABASE"');
+        expect(toml).toContain('database_name = "custom-db"');
+        expect(toml).toContain('binding = "MY_KV"');
+        expect(toml).toContain('binding = "MY_R2"');
+        expect(toml).toContain('bucket_name = "custom-files"');
+
+        // Should not have old bindings
+        expect(toml).not.toContain('binding = "DATABASE"');
+        expect(toml).not.toContain('binding = "KV"');
+        expect(toml).not.toContain('binding = "R2_BUCKET"');
+        expect(toml).not.toContain('bucket_name = "better-auth-cloudflare-files"');
+    });
+
+    test("Hyperdrive Postgres + KV + R2", () => {
+        // For Hyperdrive, we start with a simpler template (no D1)
+        const hyperdriveTemplate = `name = "my-app"
+compatibility_date = "2025-03-01"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "old-kv-id"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "old-bucket"
+`;
+
+        let toml = hyperdriveTemplate;
+
+        // User chooses Hyperdrive + KV + R2
+        toml = clearAllKvBlocks(toml);
+        toml = appendOrReplaceKvNamespaceBlock(toml, "KV", "kv-12345");
+        toml = clearAllR2Blocks(toml);
+        toml = appendOrReplaceR2Block(toml, "FILES", "my-files");
+
+        // Should have KV and R2 but no D1
+        expect(toml).toContain("[[kv_namespaces]]");
+        expect(toml).toContain("[[r2_buckets]]");
+        expect(toml).not.toContain("[[d1_databases]]");
+
+        expect(toml).toContain('binding = "KV"');
+        expect(toml).toContain('binding = "FILES"');
+        expect(toml).toContain('bucket_name = "my-files"');
+
+        // Should not have old values
+        expect(toml).not.toContain('binding = "R2_BUCKET"');
+        expect(toml).not.toContain('bucket_name = "old-bucket"');
+    });
+});
+
+describe("TOML Validation", () => {
+    test("validates binding name format", () => {
+        // Test valid binding names
+        const validBindings = ["DATABASE", "KV", "R2_BUCKET", "MY_FILES", "TEST123"];
+
+        for (const binding of validBindings) {
+            let toml = baseTemplate;
+            toml = clearAllKvBlocks(toml);
+            toml = appendOrReplaceKvNamespaceBlock(toml, binding, "test-id");
+
+            expect(toml).toContain(`binding = "${binding}"`);
+            expect((toml.match(/\[\[kv_namespaces\]\]/g) || []).length).toBe(1);
+        }
+    });
+
+    test("handles special characters in names", () => {
+        let toml = baseTemplate;
+
+        // Test names with hyphens and underscores
+        toml = updateD1Block(toml, "DATABASE", "my-app_test-db");
+        toml = clearAllR2Blocks(toml);
+        toml = appendOrReplaceR2Block(toml, "R2_BUCKET", "my-app_test-files");
+
+        expect(toml).toContain('database_name = "my-app_test-db"');
+        expect(toml).toContain('bucket_name = "my-app_test-files"');
+    });
+
+    test("preserves TOML structure and formatting", () => {
+        let toml = baseTemplate;
+
+        // Apply all transformations
+        toml = updateD1Block(toml, "DATABASE", "test-db");
+        toml = clearAllKvBlocks(toml);
+        toml = appendOrReplaceKvNamespaceBlock(toml, "KV", "kv-id");
+        toml = clearAllR2Blocks(toml);
+        toml = appendOrReplaceR2Block(toml, "R2_BUCKET", "test-files");
+
+        // Should preserve comments and structure
+        expect(toml).toContain("# For more details on how to configure Wrangler");
+        expect(toml).toContain("[assets]");
+        expect(toml).toContain("[observability]");
+        expect(toml).toContain("[placement]");
+        expect(toml).toContain('compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]');
+    });
+
+    test("handles empty/minimal configurations", () => {
+        const minimalTemplate = `name = "test-app"
+compatibility_date = "2025-03-01"
+`;
+
+        let toml = minimalTemplate;
+
+        // Add only KV
+        toml = appendOrReplaceKvNamespaceBlock(toml, "KV", "kv-id");
+
+        expect(toml).toContain("[[kv_namespaces]]");
+        expect(toml).toContain('binding = "KV"');
+        expect(toml).toContain('id = "kv-id"');
+
+        // Should not have other blocks
+        expect(toml).not.toContain("[[d1_databases]]");
+        expect(toml).not.toContain("[[r2_buckets]]");
+    });
+});
+
+describe("TOML Syntax Validation", () => {
+    test("all generated TOML is parseable by TOML parsers", () => {
+        const testCases = [
+            {
+                name: "D1 + KV + R2 with defaults (dynamic naming)",
+                transform: (toml: string) => {
+                    const appName = "test-app";
+                    let result = toml;
+                    result = updateD1Block(result, "DATABASE", `${appName}-db`);
+                    result = clearAllKvBlocks(result);
+                    result = appendOrReplaceKvNamespaceBlock(result, "KV", "kv-12345");
+                    result = clearAllR2Blocks(result);
+                    result = appendOrReplaceR2Block(result, "R2_BUCKET", `${appName}-files`);
+                    return result;
+                },
+            },
+            {
+                name: "Custom bindings with special names",
+                transform: (toml: string) => {
+                    let result = toml;
+                    result = updateD1Block(result, "MY_DATABASE", "test-app_v2-db");
+                    result = clearAllKvBlocks(result);
+                    result = appendOrReplaceKvNamespaceBlock(result, "CACHE_STORE", "kv-abc123");
+                    result = clearAllR2Blocks(result);
+                    result = appendOrReplaceR2Block(result, "FILE_STORAGE", "test-app_v2-files");
+                    return result;
+                },
+            },
+            {
+                name: "Minimal configuration",
+                transform: (toml: string) => {
+                    const appName = "minimal-app";
+                    let result = toml;
+                    result = clearAllKvBlocks(result);
+                    result = clearAllR2Blocks(result);
+                    result = updateD1Block(result, "DATABASE", `${appName}-db`);
+                    return result;
+                },
+            },
+            {
+                name: "KV and R2 only",
+                transform: (toml: string) => {
+                    const appName = "storage-app";
+                    let result = toml;
+                    result = clearAllKvBlocks(result);
+                    result = appendOrReplaceKvNamespaceBlock(result, "KV", "kv-only-123");
+                    result = clearAllR2Blocks(result);
+                    result = appendOrReplaceR2Block(result, "FILES", `${appName}-files`);
+                    return result;
+                },
+            },
+        ];
+
+        for (const testCase of testCases) {
+            const transformedToml = testCase.transform(baseTemplate);
+
+            // Attempt to parse the TOML - this will throw if invalid
+            expect(() => {
+                const parsed = TOML.parse(transformedToml);
+
+                // Verify the parsed structure makes sense
+                expect(parsed.name).toBeDefined();
+                expect(parsed.compatibility_date).toBeDefined();
+
+                // Log success for debugging and verify dynamic names
+                console.log(`✅ ${testCase.name}: Valid TOML with ${Object.keys(parsed).length} top-level keys`);
+
+                // Verify dynamic naming is working
+                if (testCase.name.includes("dynamic naming") && Array.isArray(parsed.d1_databases)) {
+                    expect((parsed.d1_databases[0] as any).database_name).toBe("test-app-db");
+                }
+                if (testCase.name.includes("Minimal") && Array.isArray(parsed.d1_databases)) {
+                    expect((parsed.d1_databases[0] as any).database_name).toBe("minimal-app-db");
+                }
+            }).not.toThrow();
+        }
+    });
+
+    test("validates wrangler-specific TOML structure", () => {
+        let toml = baseTemplate;
+
+        // Apply full configuration
+        toml = updateD1Block(toml, "DATABASE", "test-db");
+        toml = clearAllKvBlocks(toml);
+        toml = appendOrReplaceKvNamespaceBlock(toml, "KV", "kv-12345");
+        toml = clearAllR2Blocks(toml);
+        toml = appendOrReplaceR2Block(toml, "R2_BUCKET", "test-files");
+
+        const parsed = TOML.parse(toml);
+
+        // Verify wrangler.toml structure
+        expect(parsed.name).toBe("better-auth-cloudflare");
+        expect(parsed.compatibility_date).toBe("2025-03-01");
+        expect(Array.isArray(parsed.compatibility_flags)).toBe(true);
+
+        // Verify D1 configuration
+        expect(Array.isArray(parsed.d1_databases)).toBe(true);
+        expect(parsed.d1_databases).toHaveLength(1);
+        expect((parsed.d1_databases as any)[0].binding).toBe("DATABASE");
+        expect((parsed.d1_databases as any)[0].database_name).toBe("test-db");
+
+        // Verify KV configuration
+        expect(Array.isArray(parsed.kv_namespaces)).toBe(true);
+        expect(parsed.kv_namespaces).toHaveLength(1);
+        expect((parsed.kv_namespaces as any)[0].binding).toBe("KV");
+        expect((parsed.kv_namespaces as any)[0].id).toBe("kv-12345");
+
+        // Verify R2 configuration
+        expect(Array.isArray(parsed.r2_buckets)).toBe(true);
+        expect(parsed.r2_buckets).toHaveLength(1);
+        expect((parsed.r2_buckets as any)[0].binding).toBe("R2_BUCKET");
+        expect((parsed.r2_buckets as any)[0].bucket_name).toBe("test-files");
+
+        // Verify other sections are preserved
+        expect(parsed.assets).toBeDefined();
+        expect(parsed.observability).toBeDefined();
+        expect(parsed.placement).toBeDefined();
+    });
+
+    test("handles edge cases and special characters", () => {
+        const edgeCases = [
+            { db: "app-with-hyphens-db", bucket: "bucket-with-hyphens" },
+            { db: "app_with_underscores_db", bucket: "bucket_with_underscores" },
+            { db: "app123db", bucket: "bucket123" },
+            { db: "a", bucket: "b" }, // Single character names
+            {
+                db: "very-long-database-name-that-might-cause-issues",
+                bucket: "very-long-bucket-name-that-might-cause-issues",
+            },
+        ];
+
+        for (const edgeCase of edgeCases) {
+            let toml = baseTemplate;
+            toml = updateD1Block(toml, "DATABASE", edgeCase.db);
+            toml = clearAllR2Blocks(toml);
+            toml = appendOrReplaceR2Block(toml, "R2_BUCKET", edgeCase.bucket);
+
+            // Should parse without errors
+            expect(() => {
+                const parsed = TOML.parse(toml);
+                expect((parsed.d1_databases as any)[0].database_name).toBe(edgeCase.db);
+                expect((parsed.r2_buckets as any)[0].bucket_name).toBe(edgeCase.bucket);
+            }).not.toThrow();
+        }
+    });
+});

--- a/cli/tests/cli-integration.test.ts
+++ b/cli/tests/cli-integration.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, test } from "bun:test";
+
+// Test the integration between CLI argument parsing and the main command handling logic
+
+describe("CLI Integration", () => {
+    test("detects CLI arguments in process.argv", () => {
+        // Simulate process.argv with CLI arguments
+        const mockArgv1 = ["node", "cli", "--app-name=test"];
+        const mockArgv2 = ["node", "cli", "generate"];
+        const mockArgv3 = ["node", "cli"];
+
+        // Test the logic that determines if CLI arguments are present
+        const hasCliArgs1 = mockArgv1.slice(2).some(arg => arg.startsWith("--"));
+        const hasCliArgs2 = mockArgv2.slice(2).some(arg => arg.startsWith("--"));
+        const hasCliArgs3 = mockArgv3.slice(2).some(arg => arg.startsWith("--"));
+
+        expect(hasCliArgs1).toBe(true);
+        expect(hasCliArgs2).toBe(false);
+        expect(hasCliArgs3).toBe(false);
+    });
+
+    test("command routing logic with CLI args", () => {
+        // Test various command scenarios
+        const scenarios = [
+            {
+                argv: ["node", "cli"],
+                expectedMode: "interactive",
+                description: "no command defaults to interactive",
+            },
+            {
+                argv: ["node", "cli", "generate"],
+                expectedMode: "interactive",
+                description: "explicit generate command is interactive",
+            },
+            {
+                argv: ["node", "cli", "--app-name=test"],
+                expectedMode: "non-interactive",
+                description: "CLI args trigger non-interactive mode",
+            },
+            {
+                argv: ["node", "cli", "generate", "--app-name=test"],
+                expectedMode: "non-interactive",
+                description: "generate with CLI args is non-interactive",
+            },
+            {
+                argv: ["node", "cli", "help"],
+                expectedMode: "help",
+                description: "help command shows help",
+            },
+            {
+                argv: ["node", "cli", "migrate"],
+                expectedMode: "interactive",
+                description: "migrate command defaults to interactive",
+            },
+            {
+                argv: ["node", "cli", "migrate", "--migrate-target=dev"],
+                expectedMode: "non-interactive",
+                description: "migrate with CLI args is non-interactive",
+            },
+            {
+                argv: ["node", "cli", "--help"],
+                expectedMode: "help",
+                description: "--help flag shows help",
+            },
+        ];
+
+        for (const scenario of scenarios) {
+            const cmd = scenario.argv[2];
+            const hasCliArgs = scenario.argv.slice(2).some(arg => arg.startsWith("--"));
+
+            let mode: string;
+            if (cmd === "help" || cmd === "-h" || cmd === "--help") {
+                mode = "help";
+            } else if (cmd === "migrate") {
+                mode = hasCliArgs ? "non-interactive" : "interactive";
+            } else if (!cmd || cmd === "generate" || hasCliArgs) {
+                if (hasCliArgs) {
+                    mode = "non-interactive";
+                } else {
+                    mode = "interactive";
+                }
+            } else {
+                mode = "help"; // unknown command shows help
+            }
+
+            expect(mode).toBe(scenario.expectedMode);
+        }
+    });
+
+    test("argument conversion to GenerateAnswers structure", () => {
+        // Test the logic that converts CLI args to the expected GenerateAnswers format
+        interface CliArgs {
+            [key: string]: string | boolean | undefined;
+        }
+
+        interface GenerateAnswers {
+            appName: string;
+            template: "hono" | "nextjs";
+            database: "d1" | "hyperdrive-postgres" | "hyperdrive-mysql";
+            geolocation: boolean;
+            kv: boolean;
+            r2: boolean;
+            d1Name?: string;
+            d1Binding?: string;
+            hdBinding?: string;
+            hdName?: string;
+            hdConnectionString?: string;
+            kvBinding?: string;
+            kvNamespaceName?: string;
+            r2Binding?: string;
+            r2BucketName?: string;
+        }
+
+        function cliArgsToAnswers(args: CliArgs): Partial<GenerateAnswers> {
+            const answers: Partial<GenerateAnswers> = {};
+
+            if (args["app-name"]) answers.appName = args["app-name"] as string;
+            if (args.template) answers.template = args.template as "hono" | "nextjs";
+            if (args.database) answers.database = args.database as "d1" | "hyperdrive-postgres" | "hyperdrive-mysql";
+
+            // D1 fields
+            if (args["d1-name"]) answers.d1Name = args["d1-name"] as string;
+            if (args["d1-binding"]) answers.d1Binding = args["d1-binding"] as string;
+
+            // Hyperdrive fields
+            if (args["hd-binding"]) answers.hdBinding = args["hd-binding"] as string;
+            if (args["hd-name"]) answers.hdName = args["hd-name"] as string;
+            if (args["hd-connection-string"]) answers.hdConnectionString = args["hd-connection-string"] as string;
+
+            // Features
+            if (args.geolocation !== undefined) answers.geolocation = Boolean(args.geolocation);
+            if (args.kv !== undefined) answers.kv = Boolean(args.kv);
+            if (args["kv-binding"]) answers.kvBinding = args["kv-binding"] as string;
+            if (args["kv-namespace-name"]) answers.kvNamespaceName = args["kv-namespace-name"] as string;
+            if (args.r2 !== undefined) answers.r2 = Boolean(args.r2);
+            if (args["r2-binding"]) answers.r2Binding = args["r2-binding"] as string;
+            if (args["r2-bucket-name"]) answers.r2BucketName = args["r2-bucket-name"] as string;
+
+            return answers;
+        }
+
+        const cliArgs: CliArgs = {
+            "app-name": "test-app",
+            template: "nextjs",
+            database: "hyperdrive-postgres",
+            "hd-connection-string": "postgres://user:pass@host:5432/db",
+            geolocation: false,
+            kv: true,
+            r2: false,
+        };
+
+        const answers = cliArgsToAnswers(cliArgs);
+
+        expect(answers.appName).toBe("test-app");
+        expect(answers.template).toBe("nextjs");
+        expect(answers.database).toBe("hyperdrive-postgres");
+        expect(answers.hdConnectionString).toBe("postgres://user:pass@host:5432/db");
+        expect(answers.geolocation).toBe(false);
+        expect(answers.kv).toBe(true);
+        expect(answers.r2).toBe(false);
+    });
+
+    test("default value application logic", () => {
+        // Test the logic that fills in defaults for missing CLI args
+        interface PartialAnswers {
+            appName?: string;
+            template?: "hono" | "nextjs";
+            database?: "d1" | "hyperdrive-postgres" | "hyperdrive-mysql";
+            geolocation?: boolean;
+            kv?: boolean;
+            r2?: boolean;
+        }
+
+        function applyDefaults(partial: PartialAnswers) {
+            const appName = partial.appName || "my-app";
+            const database = partial.database || "d1";
+            const kv = partial.kv !== undefined ? partial.kv : true;
+            const r2 = partial.r2 !== undefined ? partial.r2 : false;
+
+            return {
+                appName,
+                template: partial.template || "hono",
+                database,
+                geolocation: partial.geolocation !== undefined ? partial.geolocation : true,
+                kv,
+                r2,
+                // D1 defaults
+                d1Name: database === "d1" ? `${appName}-db` : undefined,
+                d1Binding: database === "d1" ? "DATABASE" : undefined,
+                // Hyperdrive defaults
+                hdBinding: database !== "d1" ? "HYPERDRIVE" : undefined,
+                hdName: database !== "d1" ? `${appName}-hyperdrive` : undefined,
+                // KV defaults
+                kvBinding: kv ? "KV" : undefined,
+                kvNamespaceName: kv ? `${appName}-kv` : undefined,
+                // R2 defaults
+                r2Binding: r2 ? "R2_BUCKET" : undefined,
+                r2BucketName: r2 ? `${appName}-files` : undefined,
+            };
+        }
+
+        // Test with minimal args
+        const minimal = { appName: "test" };
+        const withDefaults = applyDefaults(minimal);
+
+        expect(withDefaults.appName).toBe("test");
+        expect(withDefaults.template).toBe("hono");
+        expect(withDefaults.database).toBe("d1");
+        expect(withDefaults.geolocation).toBe(true);
+        expect(withDefaults.kv).toBe(true);
+        expect(withDefaults.r2).toBe(false);
+        expect(withDefaults.d1Name).toBe("test-db");
+        expect(withDefaults.d1Binding).toBe("DATABASE");
+
+        // Test with hyperdrive
+        const hyperdrive = { database: "hyperdrive-postgres" as const, appName: "pg-app" };
+        const hyperdriveDefaults = applyDefaults(hyperdrive);
+
+        expect(hyperdriveDefaults.hdBinding).toBe("HYPERDRIVE");
+        expect(hyperdriveDefaults.hdName).toBe("pg-app-hyperdrive");
+        expect(hyperdriveDefaults.d1Name).toBeUndefined();
+        expect(hyperdriveDefaults.d1Binding).toBeUndefined();
+    });
+
+    test("required field validation for non-interactive mode", () => {
+        // Test validation that ensures required fields are present for non-interactive mode
+        const scenarios = [
+            {
+                args: { database: "hyperdrive-postgres" },
+                shouldError: true,
+                description: "hyperdrive requires connection string",
+            },
+            {
+                args: { database: "hyperdrive-postgres", "hd-connection-string": "postgres://localhost/db" },
+                shouldError: false,
+                description: "hyperdrive with connection string is valid",
+            },
+            {
+                args: { database: "d1" },
+                shouldError: false,
+                description: "d1 doesn't require connection string",
+            },
+        ];
+
+        for (const scenario of scenarios) {
+            const database = scenario.args.database as string;
+            const connectionString = scenario.args["hd-connection-string"] as string | undefined;
+
+            const hasError = database !== "d1" && !connectionString;
+            expect(hasError).toBe(scenario.shouldError);
+        }
+    });
+});
+
+describe("Help Text Validation", () => {
+    test("help text contains all argument options", () => {
+        const requiredHelpElements = [
+            "--app-name",
+            "--template",
+            "--database",
+            "--geolocation",
+            "--kv",
+            "--r2",
+            "--d1-name",
+            "--d1-binding",
+            "--hd-name",
+            "--hd-binding",
+            "--hd-connection-string",
+            "--kv-binding",
+            "--kv-namespace-name",
+            "--r2-binding",
+            "--r2-bucket-name",
+            "hono | nextjs",
+            "d1 | hyperdrive-postgres | hyperdrive-mysql",
+            "Examples:",
+        ];
+
+        // This would test that the help text includes all the required elements
+        // In a real implementation, we'd capture the help output and verify it contains these
+        for (const element of requiredHelpElements) {
+            expect(typeof element).toBe("string");
+            expect(element.length).toBeGreaterThan(0);
+        }
+    });
+
+    test("help examples are valid CLI invocations", () => {
+        const exampleCommands = [
+            ["--app-name=my-hono-app", "--template=hono", "--database=d1"],
+            [
+                "--app-name=my-next-app",
+                "--template=nextjs",
+                "--database=hyperdrive-postgres",
+                "--hd-connection-string=postgres://user:pass@host:5432/db",
+            ],
+            ["--app-name=minimal-app", "--kv=false", "--r2=false"],
+        ];
+
+        // Verify that all example commands would parse correctly
+        for (const example of exampleCommands) {
+            const mockArgv = ["node", "cli", ...example];
+
+            // Basic parsing test - should not throw
+            let parsedSuccessfully = true;
+            try {
+                const hasCliArgs = mockArgv.slice(2).some(arg => arg.startsWith("--"));
+                expect(hasCliArgs).toBe(true);
+            } catch {
+                parsedSuccessfully = false;
+            }
+
+            expect(parsedSuccessfully).toBe(true);
+        }
+    });
+});

--- a/cli/tests/command-parsing.test.ts
+++ b/cli/tests/command-parsing.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "child_process";
+
+// Mock command output parsing functions that would be used in the CLI
+function parseWranglerD1Output(output: string): { id: string; name: string } | null {
+    // Parse: ✅ Successfully created DB 'my-db'! New database ID: abc123
+    const match = output.match(/Successfully created DB '([^']+)'.*?ID:\s*([a-zA-Z0-9-]+)/is);
+    if (match) {
+        return { name: match[1], id: match[2] };
+    }
+    return null;
+}
+
+function parseWranglerKvOutput(output: string): { id: string; title?: string } | null {
+    // Parse: 🌀 Creating namespace with title "my-app-sessions"
+    // ✅ Success! Add the following to your configuration file:
+    // id = "abc123"
+    const titleMatch = output.match(/Creating namespace with title "([^"]+)"/);
+    const idMatch = output.match(/id\s*=\s*"([^"]+)"/);
+
+    if (idMatch) {
+        return {
+            id: idMatch[1],
+            title: titleMatch ? titleMatch[1] : undefined,
+        };
+    }
+    return null;
+}
+
+function parseWranglerR2Output(output: string): { bucketName: string } | null {
+    // Parse: ✅ Successfully created R2 bucket 'my-bucket'!
+    const match = output.match(/Successfully created R2 bucket '([^']+)'/i);
+    if (match) {
+        return { bucketName: match[1] };
+    }
+    return null;
+}
+
+function parseWranglerHyperdriveOutput(output: string): { id: string; name: string } | null {
+    // Parse: ✅ Successfully created Hyperdrive config 'my-hyperdrive'!
+    // ID: def456-ghi789-jkl012
+    const nameMatch = output.match(/Successfully created Hyperdrive config '([^']+)'/i);
+    const idMatch = output.match(/ID:\s*([a-zA-Z0-9-]+)/is);
+
+    if (nameMatch && idMatch) {
+        return { name: nameMatch[1], id: idMatch[1] };
+    }
+    return null;
+}
+
+function validateProjectName(name: string): string | undefined {
+    if (!name || name.trim().length === 0) {
+        return "Project name is required";
+    }
+    if (name.length > 50) {
+        return "Project name must be 50 characters or less";
+    }
+    if (!/^[a-z0-9-]+$/.test(name)) {
+        return "Use only lowercase letters, numbers, and hyphens";
+    }
+    if (name.startsWith("-") || name.endsWith("-")) {
+        return "Cannot start or end with hyphen";
+    }
+    return undefined;
+}
+
+function validateDatabaseUrl(url: string, type: "postgres" | "mysql"): string | undefined {
+    if (!url || url.trim().length === 0) {
+        return "Database URL is required";
+    }
+
+    if (type === "postgres") {
+        if (!url.startsWith("postgres://") && !url.startsWith("postgresql://")) {
+            return "PostgreSQL URL must start with postgres:// or postgresql://";
+        }
+    } else if (type === "mysql") {
+        if (!url.startsWith("mysql://")) {
+            return "MySQL URL must start with mysql://";
+        }
+    }
+
+    // Basic URL validation
+    try {
+        new URL(url);
+    } catch {
+        return "Invalid database URL format";
+    }
+
+    return undefined;
+}
+
+describe("Command output parsing", () => {
+    test("parses D1 database creation output", () => {
+        const output = `🌀 Creating D1 database 'my-test-db'...
+✅ Successfully created DB 'my-test-db'! New database ID: 12345678-abcd-efgh-ijkl-mnopqrstuvwx`;
+
+        const result = parseWranglerD1Output(output);
+        expect(result).toEqual({
+            name: "my-test-db",
+            id: "12345678-abcd-efgh-ijkl-mnopqrstuvwx",
+        });
+    });
+
+    test("parses KV namespace creation output", () => {
+        const output = `🌀 Creating namespace with title "my-app-sessions"
+✅ Success! Add the following to your configuration file:
+id = "abc123def456ghi789jkl012mno345pqr678"`;
+
+        const result = parseWranglerKvOutput(output);
+        expect(result).toEqual({
+            id: "abc123def456ghi789jkl012mno345pqr678",
+            title: "my-app-sessions",
+        });
+    });
+
+    test("parses R2 bucket creation output", () => {
+        const output = `🌀 Creating R2 bucket 'my-user-files'...
+✅ Successfully created R2 bucket 'my-user-files'!`;
+
+        const result = parseWranglerR2Output(output);
+        expect(result).toEqual({
+            bucketName: "my-user-files",
+        });
+    });
+
+    test("parses Hyperdrive creation output", () => {
+        const output = `🌀 Creating Hyperdrive config 'my-postgres-db'...
+✅ Successfully created Hyperdrive config 'my-postgres-db'!
+ID: def456-ghi789-jkl012-mno345-pqr678-stu901`;
+
+        const result = parseWranglerHyperdriveOutput(output);
+        expect(result).toEqual({
+            name: "my-postgres-db",
+            id: "def456-ghi789-jkl012-mno345-pqr678-stu901",
+        });
+    });
+
+    test("returns null for malformed D1 output", () => {
+        const output = "Some error occurred during database creation";
+        expect(parseWranglerD1Output(output)).toBeNull();
+    });
+
+    test("returns null for malformed KV output", () => {
+        const output = "Failed to create namespace";
+        expect(parseWranglerKvOutput(output)).toBeNull();
+    });
+});
+
+describe("Input validation", () => {
+    test("validates project names", () => {
+        expect(validateProjectName("my-app")).toBeUndefined();
+        expect(validateProjectName("my-app-123")).toBeUndefined();
+        expect(validateProjectName("simple")).toBeUndefined();
+
+        expect(validateProjectName("")).toBeTruthy();
+        expect(validateProjectName("My-App")).toBeTruthy(); // uppercase
+        expect(validateProjectName("my_app")).toBeTruthy(); // underscore
+        expect(validateProjectName("-my-app")).toBeTruthy(); // starts with hyphen
+        expect(validateProjectName("my-app-")).toBeTruthy(); // ends with hyphen
+        expect(validateProjectName("a".repeat(51))).toBeTruthy(); // too long
+    });
+
+    test("validates PostgreSQL URLs", () => {
+        expect(validateDatabaseUrl("postgres://user:pass@host:5432/db", "postgres")).toBeUndefined();
+        expect(validateDatabaseUrl("postgresql://user:pass@host:5432/db", "postgres")).toBeUndefined();
+
+        expect(validateDatabaseUrl("", "postgres")).toBeTruthy();
+        expect(validateDatabaseUrl("mysql://user:pass@host:3306/db", "postgres")).toBeTruthy();
+        expect(validateDatabaseUrl("not-a-url", "postgres")).toBeTruthy();
+    });
+
+    test("validates MySQL URLs", () => {
+        expect(validateDatabaseUrl("mysql://user:pass@host:3306/db", "mysql")).toBeUndefined();
+
+        expect(validateDatabaseUrl("", "mysql")).toBeTruthy();
+        expect(validateDatabaseUrl("postgres://user:pass@host:5432/db", "mysql")).toBeTruthy();
+        expect(validateDatabaseUrl("invalid-url", "mysql")).toBeTruthy();
+    });
+});
+
+describe("Command availability", () => {
+    function commandAvailable(command: string): boolean {
+        try {
+            const result = spawnSync(command, ["--version"], { stdio: "pipe" });
+            return (result.status ?? 1) === 0;
+        } catch {
+            return false;
+        }
+    }
+
+    test("detects available commands", () => {
+        // npm should be available in most environments
+        expect(commandAvailable("npm")).toBe(true);
+        // A non-existent command should return false
+        expect(commandAvailable("definitely-not-a-real-command-12345")).toBe(false);
+    });
+
+    test("handles wrangler availability check", () => {
+        // This test checks the logic without requiring wrangler to be installed
+        const wranglerAvailable = commandAvailable("wrangler");
+        expect(typeof wranglerAvailable).toBe("boolean");
+        // The result can be true or false depending on the environment
+        // but it should always be a boolean
+    });
+});

--- a/cli/tests/config-generation.test.ts
+++ b/cli/tests/config-generation.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "bun:test";
+
+// Mock configuration generation functions
+interface GenerateAnswers {
+    appName: string;
+    template: "hono" | "nextjs";
+    database: "d1" | "hyperdrive-postgres" | "hyperdrive-mysql";
+    d1Name?: string;
+    d1Binding?: string;
+    hdBinding?: string;
+    hdName?: string;
+    hdConnectionString?: string;
+    geolocation: boolean;
+    kv: boolean;
+    kvBinding?: string;
+    kvNamespaceName?: string;
+    r2: boolean;
+    r2Binding?: string;
+    r2BucketName?: string;
+}
+
+function generateProjectConfig(answers: GenerateAnswers) {
+    return {
+        name: answers.appName,
+        template: answers.template,
+        database: {
+            type: answers.database,
+            ...(answers.database === "d1" && {
+                d1Name: answers.d1Name,
+                d1Binding: answers.d1Binding,
+            }),
+            ...(answers.database.startsWith("hyperdrive") && {
+                hdBinding: answers.hdBinding,
+                hdName: answers.hdName,
+                hdConnectionString: answers.hdConnectionString,
+            }),
+        },
+        features: {
+            geolocation: answers.geolocation,
+            kv: answers.kv
+                ? {
+                      binding: answers.kvBinding,
+                      namespaceName: answers.kvNamespaceName,
+                  }
+                : false,
+            r2: answers.r2
+                ? {
+                      binding: answers.r2Binding,
+                      bucketName: answers.r2BucketName,
+                  }
+                : false,
+        },
+        createdAt: new Date().toISOString(),
+    };
+}
+
+function generateWranglerCommands(answers: GenerateAnswers): string[] {
+    const commands: string[] = [];
+
+    if (answers.database === "d1" && answers.d1Name) {
+        commands.push(`wrangler d1 create ${answers.d1Name}`);
+    }
+
+    if (answers.database.startsWith("hyperdrive") && answers.hdName && answers.hdConnectionString) {
+        commands.push(
+            `wrangler hyperdrive create ${answers.hdName} --connection-string="${answers.hdConnectionString}"`
+        );
+    }
+
+    if (answers.kv && answers.kvNamespaceName) {
+        commands.push(`wrangler kv:namespace create "${answers.kvNamespaceName}"`);
+    }
+
+    if (answers.r2 && answers.r2BucketName) {
+        commands.push(`wrangler r2 bucket create ${answers.r2BucketName}`);
+    }
+
+    return commands;
+}
+
+function generateInstallCommands(answers: GenerateAnswers, packageManager: string): string[] {
+    const commands: string[] = [];
+    const installCmd = packageManager === "npm" ? "npm install" : `${packageManager} add`;
+
+    // Base install
+    commands.push(packageManager === "npm" ? "npm install" : `${packageManager} install`);
+
+    // Database-specific dependencies
+    if (answers.database === "hyperdrive-postgres") {
+        commands.push(`${installCmd} postgres`);
+    } else if (answers.database === "hyperdrive-mysql") {
+        commands.push(`${installCmd} mysql2`);
+    }
+
+    return commands;
+}
+
+function generateScriptCommands(answers: GenerateAnswers, packageManager: string): string[] {
+    const runCmd = packageManager === "npm" ? "npm run" : `${packageManager} run`;
+    const commands: string[] = [];
+
+    // Always generate auth and db commands
+    commands.push(`${runCmd} auth:update`);
+    commands.push(`${runCmd} db:generate`);
+
+    // Migration commands depend on database type
+    if (answers.database === "d1") {
+        commands.push(`${runCmd} db:migrate:dev`);
+        commands.push(`${runCmd} db:migrate:prod`);
+    } else {
+        commands.push(`${runCmd} db:push`); // Hyperdrive typically uses push instead of migrate
+    }
+
+    return commands;
+}
+
+describe("Configuration generation", () => {
+    test("generates D1 project config", () => {
+        const answers: GenerateAnswers = {
+            appName: "my-d1-app",
+            template: "hono",
+            database: "d1",
+            d1Name: "my-d1-db",
+            d1Binding: "DATABASE",
+            geolocation: true,
+            kv: true,
+            kvBinding: "KV_SESSIONS",
+            kvNamespaceName: "my-app-sessions",
+            r2: false,
+        };
+
+        const config = generateProjectConfig(answers);
+
+        expect(config.name).toBe("my-d1-app");
+        expect(config.template).toBe("hono");
+        expect(config.database.type).toBe("d1");
+        expect(config.database.d1Name).toBe("my-d1-db");
+        expect(config.database.d1Binding).toBe("DATABASE");
+        expect(config.features.geolocation).toBe(true);
+        expect(config.features.kv).toEqual({
+            binding: "KV_SESSIONS",
+            namespaceName: "my-app-sessions",
+        });
+        expect(config.features.r2).toBe(false);
+    });
+
+    test("generates Hyperdrive Postgres project config", () => {
+        const answers: GenerateAnswers = {
+            appName: "my-postgres-app",
+            template: "nextjs",
+            database: "hyperdrive-postgres",
+            hdBinding: "HYPERDRIVE",
+            hdName: "my-postgres-hd",
+            hdConnectionString: "postgres://user:pass@host:5432/db",
+            geolocation: false,
+            kv: false,
+            r2: true,
+            r2Binding: "FILE_STORAGE",
+            r2BucketName: "my-app-files",
+        };
+
+        const config = generateProjectConfig(answers);
+
+        expect(config.database.type).toBe("hyperdrive-postgres");
+        expect(config.database.hdBinding).toBe("HYPERDRIVE");
+        expect(config.database.hdName).toBe("my-postgres-hd");
+        expect(config.database.hdConnectionString).toBe("postgres://user:pass@host:5432/db");
+        expect(config.features.r2).toEqual({
+            binding: "FILE_STORAGE",
+            bucketName: "my-app-files",
+        });
+    });
+
+    test("generates correct wrangler commands for D1", () => {
+        const answers: GenerateAnswers = {
+            appName: "test-app",
+            template: "hono",
+            database: "d1",
+            d1Name: "test-db",
+            d1Binding: "DATABASE",
+            geolocation: false,
+            kv: true,
+            kvBinding: "KV",
+            kvNamespaceName: "test-sessions",
+            r2: true,
+            r2Binding: "R2_BUCKET",
+            r2BucketName: "test-files",
+        };
+
+        const commands = generateWranglerCommands(answers);
+
+        expect(commands).toContain("wrangler d1 create test-db");
+        expect(commands).toContain('wrangler kv:namespace create "test-sessions"');
+        expect(commands).toContain("wrangler r2 bucket create test-files");
+    });
+
+    test("generates correct wrangler commands for Hyperdrive", () => {
+        const answers: GenerateAnswers = {
+            appName: "test-app",
+            template: "nextjs",
+            database: "hyperdrive-mysql",
+            hdBinding: "HYPERDRIVE",
+            hdName: "test-mysql",
+            hdConnectionString: "mysql://user:pass@host:3306/db",
+            geolocation: false,
+            kv: false,
+            r2: false,
+        };
+
+        const commands = generateWranglerCommands(answers);
+
+        expect(commands).toContain(
+            'wrangler hyperdrive create test-mysql --connection-string="mysql://user:pass@host:3306/db"'
+        );
+        expect(commands).not.toContain("wrangler d1 create");
+        expect(commands).not.toContain("wrangler kv:namespace create");
+        expect(commands).not.toContain("wrangler r2 bucket create");
+    });
+
+    test("generates install commands for different package managers", () => {
+        const answers: GenerateAnswers = {
+            appName: "test-app",
+            template: "hono",
+            database: "hyperdrive-postgres",
+            hdBinding: "HYPERDRIVE",
+            geolocation: false,
+            kv: false,
+            r2: false,
+        };
+
+        const bunCommands = generateInstallCommands(answers, "bun");
+        const npmCommands = generateInstallCommands(answers, "npm");
+
+        expect(bunCommands).toContain("bun install");
+        expect(bunCommands).toContain("bun add postgres");
+
+        expect(npmCommands).toContain("npm install");
+        expect(npmCommands).toContain("npm install postgres");
+    });
+
+    test("generates script commands for D1", () => {
+        const answers: GenerateAnswers = {
+            appName: "test-app",
+            template: "hono",
+            database: "d1",
+            d1Binding: "DATABASE",
+            geolocation: false,
+            kv: false,
+            r2: false,
+        };
+
+        const commands = generateScriptCommands(answers, "bun");
+
+        expect(commands).toContain("bun run auth:update");
+        expect(commands).toContain("bun run db:generate");
+        expect(commands).toContain("bun run db:migrate:dev");
+        expect(commands).toContain("bun run db:migrate:prod");
+    });
+
+    test("generates script commands for Hyperdrive", () => {
+        const answers: GenerateAnswers = {
+            appName: "test-app",
+            template: "nextjs",
+            database: "hyperdrive-postgres",
+            hdBinding: "HYPERDRIVE",
+            geolocation: false,
+            kv: false,
+            r2: false,
+        };
+
+        const commands = generateScriptCommands(answers, "pnpm");
+
+        expect(commands).toContain("pnpm run auth:update");
+        expect(commands).toContain("pnpm run db:generate");
+        expect(commands).toContain("pnpm run db:push");
+        expect(commands).not.toContain("pnpm run db:migrate:dev");
+    });
+
+    test("handles minimal configuration", () => {
+        const answers: GenerateAnswers = {
+            appName: "minimal-app",
+            template: "hono",
+            database: "d1",
+            d1Name: "minimal-db",
+            d1Binding: "DATABASE",
+            geolocation: false,
+            kv: false,
+            r2: false,
+        };
+
+        const config = generateProjectConfig(answers);
+        const commands = generateWranglerCommands(answers);
+
+        expect(config.features.kv).toBe(false);
+        expect(config.features.r2).toBe(false);
+        expect(commands).toHaveLength(1); // Only D1 command
+        expect(commands[0]).toBe("wrangler d1 create minimal-db");
+    });
+});

--- a/cli/tests/dynamic-naming.test.ts
+++ b/cli/tests/dynamic-naming.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+// Test to verify that default values use dynamic app names correctly
+describe("Dynamic Default Values", () => {
+    test("default values should use app name dynamically", () => {
+        // Simulate the CLI's default value generation logic
+        const testCases = [
+            {
+                appName: "my-awesome-app",
+                expected: {
+                    db: "my-awesome-app-db",
+                    kv: "my-awesome-app-kv",
+                    r2: "my-awesome-app-files",
+                    hd: "my-awesome-app-hyperdrive",
+                },
+            },
+            {
+                appName: "blog-site",
+                expected: { db: "blog-site-db", kv: "blog-site-kv", r2: "blog-site-files", hd: "blog-site-hyperdrive" },
+            },
+            {
+                appName: "ecommerce",
+                expected: { db: "ecommerce-db", kv: "ecommerce-kv", r2: "ecommerce-files", hd: "ecommerce-hyperdrive" },
+            },
+            {
+                appName: "api-v2",
+                expected: { db: "api-v2-db", kv: "api-v2-kv", r2: "api-v2-files", hd: "api-v2-hyperdrive" },
+            },
+        ];
+
+        for (const testCase of testCases) {
+            // This simulates the logic from the CLI prompts
+            const results = { appName: testCase.appName };
+
+            // D1 database name
+            const d1Name = `${(results.appName as string) || "my-app"}-db`;
+            expect(d1Name).toBe(testCase.expected.db);
+
+            // Hyperdrive instance name
+            const hdName = `${(results.appName as string) || "my-app"}-hyperdrive`;
+            expect(hdName).toBe(testCase.expected.hd);
+
+            // KV namespace name
+            const kvName = `${(results.appName as string) || "my-app"}-kv`;
+            expect(kvName).toBe(testCase.expected.kv);
+
+            // R2 bucket name
+            const r2Name = `${(results.appName as string) || "my-app"}-files`;
+            expect(r2Name).toBe(testCase.expected.r2);
+        }
+    });
+
+    test("fallback to my-app when appName is undefined", () => {
+        const results = { appName: undefined as string | undefined };
+
+        const d1Name = `${results.appName || "my-app"}-db`;
+        const kvName = `${results.appName || "my-app"}-kv`;
+        const r2Name = `${results.appName || "my-app"}-files`;
+        const hdName = `${results.appName || "my-app"}-hyperdrive`;
+
+        expect(d1Name).toBe("my-app-db");
+        expect(kvName).toBe("my-app-kv");
+        expect(r2Name).toBe("my-app-files");
+        expect(hdName).toBe("my-app-hyperdrive");
+    });
+
+    test("handles empty string appName", () => {
+        const results = { appName: "" };
+
+        const d1Name = `${results.appName || "my-app"}-db`;
+        const kvName = `${results.appName || "my-app"}-kv`;
+        const r2Name = `${results.appName || "my-app"}-files`;
+        const hdName = `${results.appName || "my-app"}-hyperdrive`;
+
+        expect(d1Name).toBe("my-app-db");
+        expect(kvName).toBe("my-app-kv");
+        expect(r2Name).toBe("my-app-files");
+        expect(hdName).toBe("my-app-hyperdrive");
+    });
+
+    test("handles special characters in app names", () => {
+        const testCases = [
+            { appName: "my-awesome_app", expected: "my-awesome_app" },
+            { appName: "app123", expected: "app123" },
+            { appName: "test-app-v2", expected: "test-app-v2" },
+        ];
+
+        for (const testCase of testCases) {
+            const results = { appName: testCase.appName };
+
+            const d1Name = `${(results.appName as string) || "my-app"}-db`;
+            const kvName = `${(results.appName as string) || "my-app"}-kv`;
+            const r2Name = `${(results.appName as string) || "my-app"}-files`;
+            const hdName = `${(results.appName as string) || "my-app"}-hyperdrive`;
+
+            expect(d1Name).toBe(`${testCase.expected}-db`);
+            expect(kvName).toBe(`${testCase.expected}-kv`);
+            expect(r2Name).toBe(`${testCase.expected}-files`);
+            expect(hdName).toBe(`${testCase.expected}-hyperdrive`);
+        }
+    });
+});

--- a/cli/tests/file-operations.test.ts
+++ b/cli/tests/file-operations.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Mock the file operations that would be used in the CLI
+function replaceInFile(filePath: string, searchValue: string, replaceValue: string): void {
+    const content = readFileSync(filePath, "utf8");
+    const updated = content.replace(new RegExp(searchValue, "g"), replaceValue);
+    writeFileSync(filePath, updated);
+}
+
+function replaceBindingInAuthFile(filePath: string, oldBinding: string, newBinding: string): void {
+    let content = readFileSync(filePath, "utf8");
+
+    // Replace specific binding patterns
+    if (oldBinding === "DATABASE") {
+        content = content.replace(new RegExp(`env\\.${oldBinding}\\b`, "g"), `env.${newBinding}`);
+    } else if (oldBinding === "KV") {
+        content = content.replace(new RegExp(`env\\?\\.${oldBinding}\\b`, "g"), `env?.${newBinding}`);
+    } else if (oldBinding === "R2_BUCKET") {
+        content = content.replace(new RegExp(`env\\.${oldBinding}\\b`, "g"), `env.${newBinding}`);
+    }
+
+    writeFileSync(filePath, content);
+}
+
+function updateEnvTypes(filePath: string, bindings: Record<string, string>): void {
+    let content = readFileSync(filePath, "utf8");
+
+    // Replace DATABASE binding
+    if (bindings.DATABASE) {
+        content = content.replace(/DATABASE:\s*D1Database/, `${bindings.DATABASE}: D1Database`);
+    }
+
+    // Replace KV binding
+    if (bindings.KV) {
+        content = content.replace(/KV:\s*KVNamespace/, `${bindings.KV}: KVNamespace`);
+    }
+
+    // Replace R2 binding
+    if (bindings.R2_BUCKET) {
+        content = content.replace(/R2_BUCKET:\s*R2Bucket/, `${bindings.R2_BUCKET}: R2Bucket`);
+    }
+
+    // Add HYPERDRIVE if needed
+    if (bindings.HYPERDRIVE) {
+        if (!content.includes("HYPERDRIVE")) {
+            content = content.replace(
+                /interface\s+Env\s*\{/,
+                `interface Env {\n    ${bindings.HYPERDRIVE}: Hyperdrive;`
+            );
+        }
+    }
+
+    writeFileSync(filePath, content);
+}
+
+const testDir = join(tmpdir(), "cli-test-files");
+
+describe("File operations", () => {
+    beforeEach(() => {
+        if (existsSync(testDir)) {
+            rmSync(testDir, { recursive: true });
+        }
+        mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        if (existsSync(testDir)) {
+            rmSync(testDir, { recursive: true });
+        }
+    });
+
+    test("replaces binding names in auth file", () => {
+        const authFile = join(testDir, "auth.ts");
+        const authContent = `import { betterAuth } from "better-auth";
+import { d1Adapter } from "better-auth/adapters/d1";
+
+export const auth = betterAuth({
+  database: d1Adapter({
+    db: env.DATABASE,
+  }),
+  plugins: [
+    cloudflareAuth({
+      kv: env?.KV,
+      r2: {
+        bucket: env.R2_BUCKET,
+      }
+    })
+  ]
+});`;
+
+        writeFileSync(authFile, authContent);
+
+        replaceBindingInAuthFile(authFile, "DATABASE", "MY_DB");
+        replaceBindingInAuthFile(authFile, "KV", "MY_KV");
+        replaceBindingInAuthFile(authFile, "R2_BUCKET", "MY_R2");
+
+        const updated = readFileSync(authFile, "utf8");
+        expect(updated).toContain("env.MY_DB");
+        expect(updated).toContain("env?.MY_KV");
+        expect(updated).toContain("env.MY_R2");
+    });
+
+    test("updates environment type definitions", () => {
+        const envFile = join(testDir, "env.d.ts");
+        const envContent = `interface Env {
+  DATABASE: D1Database;
+  KV: KVNamespace;
+  R2_BUCKET: R2Bucket;
+}`;
+
+        writeFileSync(envFile, envContent);
+
+        updateEnvTypes(envFile, {
+            DATABASE: "MY_DATABASE",
+            KV: "SESSIONS",
+            R2_BUCKET: "FILE_STORAGE",
+        });
+
+        const updated = readFileSync(envFile, "utf8");
+        expect(updated).toContain("MY_DATABASE: D1Database");
+        expect(updated).toContain("SESSIONS: KVNamespace");
+        expect(updated).toContain("FILE_STORAGE: R2Bucket");
+    });
+
+    test("adds Hyperdrive to env types", () => {
+        const envFile = join(testDir, "env.d.ts");
+        const envContent = `interface Env {
+  DATABASE: D1Database;
+}`;
+
+        writeFileSync(envFile, envContent);
+
+        updateEnvTypes(envFile, {
+            HYPERDRIVE: "MY_HYPERDRIVE",
+        });
+
+        const updated = readFileSync(envFile, "utf8");
+        expect(updated).toContain("MY_HYPERDRIVE: Hyperdrive");
+    });
+
+    test("converts D1 to Postgres configuration", () => {
+        const authFile = join(testDir, "auth.ts");
+        const d1Content = `import { betterAuth } from "better-auth";
+import { d1Adapter } from "better-auth/adapters/d1";
+
+export const auth = betterAuth({
+  database: d1Adapter({
+    db: env.DATABASE,
+  }),
+});`;
+
+        writeFileSync(authFile, d1Content);
+
+        // Simulate converting to Postgres
+        let content = readFileSync(authFile, "utf8");
+        content = content.replace(
+            'import { d1Adapter } from "better-auth/adapters/d1";',
+            'import { postgresAdapter } from "better-auth/adapters/postgres";'
+        );
+        content = content.replace(/d1Adapter\(\{[\s\S]*?\}\)/, "postgresAdapter({ db: env.HYPERDRIVE })");
+        writeFileSync(authFile, content);
+
+        const updated = readFileSync(authFile, "utf8");
+        expect(updated).toContain("postgresAdapter");
+        expect(updated).toContain("env.HYPERDRIVE");
+        expect(updated).not.toContain("d1Adapter");
+    });
+
+    test("updates drizzle config for different databases", () => {
+        const configFile = join(testDir, "drizzle.config.ts");
+        const d1Config = `import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/db/schema.ts",
+  out: "./drizzle",
+  dialect: "sqlite",
+  driver: "d1-http",
+});`;
+
+        writeFileSync(configFile, d1Config);
+
+        // Convert to PostgreSQL
+        let content = readFileSync(configFile, "utf8");
+        content = content.replace('"sqlite"', '"postgresql"');
+        content = content.replace(/,\s*driver:\s*"d1-http"/, "");
+        writeFileSync(configFile, content);
+
+        const updated = readFileSync(configFile, "utf8");
+        expect(updated).toContain('"postgresql"');
+        expect(updated).not.toContain('"d1-http"');
+    });
+});

--- a/cli/tests/json-manipulation.test.ts
+++ b/cli/tests/json-manipulation.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, unlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { updateJSON, type JSONObject } from "../src/lib/helpers";
+
+const testFile = join(tmpdir(), "test-package.json");
+
+describe("JSON manipulation", () => {
+    beforeEach(() => {
+        // Create a test package.json
+        const testPackage = {
+            name: "test-app",
+            version: "1.0.0",
+            scripts: {
+                dev: "wrangler dev",
+                build: "wrangler deploy",
+            },
+            dependencies: {
+                "better-auth": "^1.0.0",
+            },
+        };
+        writeFileSync(testFile, JSON.stringify(testPackage, null, 2));
+    });
+
+    afterEach(() => {
+        if (existsSync(testFile)) {
+            unlinkSync(testFile);
+        }
+    });
+
+    test("updates package name", () => {
+        updateJSON(testFile, json => ({
+            ...json,
+            name: "my-new-app",
+        }));
+
+        const updated = JSON.parse(require("fs").readFileSync(testFile, "utf8"));
+        expect(updated.name).toBe("my-new-app");
+    });
+
+    test("adds new dependencies", () => {
+        updateJSON(testFile, json => {
+            const deps = json.dependencies as JSONObject;
+            return {
+                ...json,
+                dependencies: {
+                    ...deps,
+                    postgres: "^3.4.0",
+                    "better-auth-cloudflare": "latest",
+                },
+            };
+        });
+
+        const updated = JSON.parse(require("fs").readFileSync(testFile, "utf8"));
+        expect(updated.dependencies.postgres).toBe("^3.4.0");
+        expect(updated.dependencies["better-auth-cloudflare"]).toBe("latest");
+    });
+
+    test("updates scripts with D1 binding name", () => {
+        const d1Binding = "MY_DATABASE";
+        updateJSON(testFile, json => {
+            const scripts = json.scripts as JSONObject;
+            return {
+                ...json,
+                scripts: {
+                    ...scripts,
+                    "db:migrate:dev": `wrangler d1 migrations apply ${d1Binding} --local`,
+                    "db:migrate:prod": `wrangler d1 migrations apply ${d1Binding} --remote`,
+                },
+            };
+        });
+
+        const updated = JSON.parse(require("fs").readFileSync(testFile, "utf8"));
+        expect(updated.scripts["db:migrate:dev"]).toBe("wrangler d1 migrations apply MY_DATABASE --local");
+        expect(updated.scripts["db:migrate:prod"]).toBe("wrangler d1 migrations apply MY_DATABASE --remote");
+    });
+
+    test("preserves existing properties when updating", () => {
+        updateJSON(testFile, json => ({
+            ...json,
+            name: "updated-name",
+        }));
+
+        const updated = JSON.parse(require("fs").readFileSync(testFile, "utf8"));
+        expect(updated.version).toBe("1.0.0");
+        expect(updated.dependencies["better-auth"]).toBe("^1.0.0");
+        expect(updated.scripts.dev).toBe("wrangler dev");
+    });
+});

--- a/cli/tests/migrate-command.test.ts
+++ b/cli/tests/migrate-command.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test";
+
+describe("Migrate Command", () => {
+    test("migrate command is recognized in CLI", () => {
+        const validCommands = ["generate", "migrate", "help", "-h", "--help"];
+
+        expect(validCommands).toContain("migrate");
+    });
+
+    test("migrate command routing logic", () => {
+        // Test migrate command scenarios
+        const scenarios = [
+            {
+                argv: ["node", "cli", "migrate"],
+                expectedCommand: "migrate",
+                expectedMode: "interactive",
+                description: "migrate command defaults to interactive",
+            },
+            {
+                argv: ["node", "cli", "migrate", "--migrate-target=dev"],
+                expectedCommand: "migrate",
+                expectedMode: "non-interactive",
+                description: "migrate with CLI args is non-interactive",
+            },
+            {
+                argv: ["node", "cli", "migrate", "--migrate-target=remote"],
+                expectedCommand: "migrate",
+                expectedMode: "non-interactive",
+                description: "migrate with remote target is non-interactive",
+            },
+            {
+                argv: ["node", "cli", "migrate", "--migrate-target=skip"],
+                expectedCommand: "migrate",
+                expectedMode: "non-interactive",
+                description: "migrate with skip target is non-interactive",
+            },
+        ];
+
+        for (const scenario of scenarios) {
+            const cmd = scenario.argv[2];
+            const hasCliArgs = scenario.argv.slice(3).some(arg => arg.startsWith("--"));
+            const expectedMode = hasCliArgs ? "non-interactive" : "interactive";
+
+            expect(cmd).toBe(scenario.expectedCommand);
+            expect(expectedMode).toBe(scenario.expectedMode);
+        }
+    });
+
+    test("migrate command validates migrate-target argument", () => {
+        const validTargets = ["dev", "remote", "skip"];
+        const invalidTargets = ["prod", "local", "production", "development", ""];
+
+        // Valid targets should be accepted
+        for (const target of validTargets) {
+            expect(validTargets).toContain(target);
+        }
+
+        // Invalid targets should be rejected
+        for (const target of invalidTargets) {
+            expect(validTargets).not.toContain(target);
+        }
+    });
+
+    test("migrate command requires project.config.json", () => {
+        // This test verifies the logic that checks for project.config.json
+        // In actual implementation, this would check existsSync(configPath)
+        const projectConfigPath = "project.config.json";
+        expect(projectConfigPath).toBe("project.config.json");
+
+        // The migrate command should fail if no project.config.json exists
+        // This would be tested in integration tests with actual file system
+    });
+
+    test("migrate command supports different database types", () => {
+        const supportedDatabases = ["d1", "hyperdrive-postgres", "hyperdrive-mysql"];
+
+        // D1 databases should support migration commands
+        expect(supportedDatabases).toContain("d1");
+
+        // Non-D1 databases should show informational message
+        expect(supportedDatabases).toContain("hyperdrive-postgres");
+        expect(supportedDatabases).toContain("hyperdrive-mysql");
+    });
+
+    test("migrate command workflow steps", () => {
+        const expectedSteps = [
+            "auth:update",
+            "db:generate",
+            "db:migrate", // conditional based on database type and user choice
+        ];
+
+        // First two steps should always run
+        expect(expectedSteps[0]).toBe("auth:update");
+        expect(expectedSteps[1]).toBe("db:generate");
+
+        // Third step is conditional
+        expect(expectedSteps[2]).toBe("db:migrate");
+    });
+
+    test("migrate command script execution order", () => {
+        // Test that scripts are called in the correct order
+        const scriptOrder = [
+            "auth:update", // First: update auth schema
+            "db:generate", // Second: generate migrations
+            "db:migrate:dev", // Third: apply migrations (if chosen)
+        ];
+
+        expect(scriptOrder[0]).toBe("auth:update");
+        expect(scriptOrder[1]).toBe("db:generate");
+        expect(scriptOrder[2]).toBe("db:migrate:dev");
+
+        // Alternative migration script for remote
+        const remoteScript = "db:migrate:prod";
+        expect(remoteScript).toBe("db:migrate:prod");
+    });
+
+    test("migrate command interactive options", () => {
+        const interactiveOptions = [
+            { value: "dev", label: "Yes, apply locally (dev)" },
+            { value: "remote", label: "Yes, apply to remote (prod)" },
+            { value: "skip", label: "No, skip migration" },
+        ];
+
+        // Should have exactly 3 options
+        expect(interactiveOptions).toHaveLength(3);
+
+        // Check option values
+        expect(interactiveOptions[0].value).toBe("dev");
+        expect(interactiveOptions[1].value).toBe("remote");
+        expect(interactiveOptions[2].value).toBe("skip");
+
+        // Check option labels contain expected text
+        expect(interactiveOptions[0].label).toContain("locally");
+        expect(interactiveOptions[1].label).toContain("remote");
+        expect(interactiveOptions[2].label).toContain("skip");
+    });
+
+    test("migrate command non-interactive defaults", () => {
+        // In non-interactive mode without migrate-target, should default to skip
+        const defaultTarget = "skip";
+        expect(defaultTarget).toBe("skip");
+
+        // With migrate-target specified, should use that value
+        const specifiedTargets = ["dev", "remote", "skip"];
+        for (const target of specifiedTargets) {
+            expect(["dev", "remote", "skip"]).toContain(target);
+        }
+    });
+
+    test("migrate command error handling", () => {
+        // Test error scenarios
+        const errorScenarios = [
+            {
+                condition: "no project.config.json",
+                expectedError: "No project.config.json found",
+            },
+            {
+                condition: "invalid migrate-target",
+                expectedError: "migrate-target must be 'dev', 'remote', or 'skip'",
+            },
+            {
+                condition: "failed auth:update",
+                expectedError: "Auth schema update failed",
+            },
+            {
+                condition: "failed db:generate",
+                expectedError: "Database migration generation failed",
+            },
+            {
+                condition: "failed db:migrate:dev",
+                expectedError: "Local migration failed",
+            },
+            {
+                condition: "failed db:migrate:prod",
+                expectedError: "Remote migration failed",
+            },
+        ];
+
+        // Each error scenario should have a specific error message
+        for (const scenario of errorScenarios) {
+            expect(scenario.expectedError).toBeTruthy();
+            expect(typeof scenario.expectedError).toBe("string");
+        }
+    });
+
+    test("migrate command success messages", () => {
+        const successMessages = [
+            "Auth schema updated.",
+            "Database migrations generated.",
+            "Migrations applied locally.",
+            "Migrations applied to remote.",
+            "Migration completed successfully!",
+        ];
+
+        for (const message of successMessages) {
+            expect(message).toBeTruthy();
+            expect(typeof message).toBe("string");
+        }
+    });
+
+    test("migrate command package manager detection", () => {
+        // The migrate command should detect and use the appropriate package manager
+        const packageManagers = ["bun", "pnpm", "yarn", "npm"];
+
+        for (const pm of packageManagers) {
+            expect(packageManagers).toContain(pm);
+        }
+
+        // Script execution should adapt to package manager
+        const scriptFormats = {
+            bun: "bun run script",
+            pnpm: "pnpm run script",
+            yarn: "yarn script",
+            npm: "npm run script",
+        };
+
+        expect(scriptFormats.bun).toContain("bun run");
+        expect(scriptFormats.pnpm).toContain("pnpm run");
+        expect(scriptFormats.yarn).toContain("yarn");
+        expect(scriptFormats.npm).toContain("npm run");
+    });
+
+    test("migrate command help text includes migrate examples", () => {
+        const expectedHelpContent = [
+            "migrate",
+            "Run migration workflow",
+            "npx @better-auth-cloudflare/cli migrate",
+            "--migrate-target=dev",
+            "auth:update, db:generate, and optionally db:migrate",
+        ];
+
+        for (const content of expectedHelpContent) {
+            expect(content).toBeTruthy();
+            expect(typeof content).toBe("string");
+        }
+    });
+
+    test("migrate command supports all CLI argument formats", () => {
+        const cliArgFormats = [
+            "--migrate-target=dev",
+            "--migrate-target dev",
+            "--migrate-target=remote",
+            "--migrate-target=skip",
+        ];
+
+        // All formats should be parseable
+        for (const format of cliArgFormats) {
+            if (format.includes("=")) {
+                const [key, value] = format.slice(2).split("=");
+                expect(key).toBe("migrate-target");
+                expect(["dev", "remote", "skip"]).toContain(value);
+            }
+        }
+    });
+
+    test("migrate command handles different project configurations", () => {
+        const projectConfigs = [
+            { database: "d1", name: "test-app", template: "hono" },
+            { database: "hyperdrive-postgres", name: "pg-app", template: "nextjs" },
+            { database: "hyperdrive-mysql", name: "mysql-app", template: "hono" },
+        ];
+
+        for (const config of projectConfigs) {
+            expect(config.database).toBeTruthy();
+            expect(config.name).toBeTruthy();
+            expect(config.template).toBeTruthy();
+
+            // D1 should support migration commands
+            if (config.database === "d1") {
+                expect(config.database).toBe("d1");
+            } else {
+                // Non-D1 should show informational message
+                expect(["hyperdrive-postgres", "hyperdrive-mysql"]).toContain(config.database);
+            }
+        }
+    });
+});

--- a/cli/tests/migrate-integration.test.ts
+++ b/cli/tests/migrate-integration.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { existsSync, writeFileSync, unlinkSync, mkdirSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+describe("Migrate Command Integration", () => {
+    let testDir: string;
+    let originalCwd: string;
+
+    beforeEach(() => {
+        // Create a temporary directory for each test
+        originalCwd = process.cwd();
+        testDir = join(tmpdir(), `migrate-test-${Date.now()}`);
+        mkdirSync(testDir, { recursive: true });
+        process.chdir(testDir);
+    });
+
+    afterEach(() => {
+        // Clean up
+        process.chdir(originalCwd);
+        if (existsSync(testDir)) {
+            rmSync(testDir, { recursive: true, force: true });
+        }
+    });
+
+    test("migrate command fails without project.config.json", () => {
+        // Ensure no project.config.json exists
+        const configPath = join(testDir, "project.config.json");
+        expect(existsSync(configPath)).toBe(false);
+
+        // The migrate command should detect missing config
+        // This would be tested by actually running the CLI in real integration tests
+    });
+
+    test("migrate command reads project.config.json correctly", () => {
+        // Create a valid project.config.json
+        const projectConfig = {
+            name: "test-app",
+            template: "hono",
+            database: "d1",
+            d1Name: "test-app-db",
+            d1Binding: "DATABASE",
+            geolocation: true,
+            kv: true,
+            kvBinding: "KV",
+            r2: false,
+        };
+
+        const configPath = join(testDir, "project.config.json");
+        writeFileSync(configPath, JSON.stringify(projectConfig, null, 2));
+
+        expect(existsSync(configPath)).toBe(true);
+
+        // The migrate command should be able to read this config
+        const readConfig = JSON.parse(require("fs").readFileSync(configPath, "utf8"));
+        expect(readConfig.database).toBe("d1");
+        expect(readConfig.name).toBe("test-app");
+    });
+
+    test("migrate command with D1 database configuration", () => {
+        // Create project config for D1 database
+        const projectConfig = {
+            name: "d1-app",
+            template: "hono",
+            database: "d1",
+            d1Name: "d1-app-db",
+            d1Binding: "DATABASE",
+            geolocation: true,
+            kv: false,
+            r2: false,
+        };
+
+        writeFileSync(join(testDir, "project.config.json"), JSON.stringify(projectConfig, null, 2));
+
+        // Create a package.json with the expected scripts
+        const packageJson = {
+            name: "d1-app",
+            scripts: {
+                "auth:update": "echo 'Running auth:update'",
+                "db:generate": "echo 'Running db:generate'",
+                "db:migrate:dev": "echo 'Running db:migrate:dev'",
+                "db:migrate:prod": "echo 'Running db:migrate:prod'",
+            },
+        };
+
+        writeFileSync(join(testDir, "package.json"), JSON.stringify(packageJson, null, 2));
+
+        // Verify the test setup
+        expect(existsSync(join(testDir, "project.config.json"))).toBe(true);
+        expect(existsSync(join(testDir, "package.json"))).toBe(true);
+
+        const config = JSON.parse(require("fs").readFileSync(join(testDir, "project.config.json"), "utf8"));
+        expect(config.database).toBe("d1");
+    });
+
+    test("migrate command with hyperdrive database configuration", () => {
+        // Create project config for Hyperdrive database
+        const projectConfig = {
+            name: "pg-app",
+            template: "nextjs",
+            database: "hyperdrive-postgres",
+            hdName: "pg-app-hyperdrive",
+            hdBinding: "HYPERDRIVE",
+            hdConnectionString: "postgres://user:pass@host:5432/db",
+            geolocation: true,
+            kv: true,
+            r2: false,
+        };
+
+        writeFileSync(join(testDir, "project.config.json"), JSON.stringify(projectConfig, null, 2));
+
+        // Create package.json
+        const packageJson = {
+            name: "pg-app",
+            scripts: {
+                "auth:update": "echo 'Running auth:update'",
+                "db:generate": "echo 'Running db:generate'",
+            },
+        };
+
+        writeFileSync(join(testDir, "package.json"), JSON.stringify(packageJson, null, 2));
+
+        const config = JSON.parse(require("fs").readFileSync(join(testDir, "project.config.json"), "utf8"));
+        expect(config.database).toBe("hyperdrive-postgres");
+
+        // For hyperdrive databases, migrate command should not offer db:migrate options
+    });
+
+    test("migrate command CLI argument parsing", () => {
+        // Test CLI argument parsing logic
+        const testCases = [
+            {
+                args: ["--migrate-target=dev"],
+                expected: { "migrate-target": "dev" },
+            },
+            {
+                args: ["--migrate-target=remote"],
+                expected: { "migrate-target": "remote" },
+            },
+            {
+                args: ["--migrate-target=skip"],
+                expected: { "migrate-target": "skip" },
+            },
+        ];
+
+        for (const testCase of testCases) {
+            // Simulate CLI argument parsing
+            const parsed: Record<string, string | boolean> = {};
+
+            for (const arg of testCase.args) {
+                if (arg.startsWith("--") && arg.includes("=")) {
+                    const [key, value] = arg.slice(2).split("=");
+                    parsed[key] = value;
+                }
+            }
+
+            expect(parsed["migrate-target"]).toBe(testCase.expected["migrate-target"]);
+        }
+    });
+
+    test("migrate command validates migrate-target values", () => {
+        const validValues = ["dev", "remote", "skip"];
+        const invalidValues = ["prod", "local", "development", "production", ""];
+
+        // Valid values should pass validation
+        for (const value of validValues) {
+            const isValid = ["dev", "remote", "skip"].includes(value);
+            expect(isValid).toBe(true);
+        }
+
+        // Invalid values should fail validation
+        for (const value of invalidValues) {
+            const isValid = ["dev", "remote", "skip"].includes(value);
+            expect(isValid).toBe(false);
+        }
+    });
+
+    test("migrate command package manager detection in test environment", () => {
+        // Create different lock files to test package manager detection
+        const lockFiles = [
+            { file: "bun.lockb", pm: "bun" },
+            { file: "pnpm-lock.yaml", pm: "pnpm" },
+            { file: "yarn.lock", pm: "yarn" },
+            { file: "package-lock.json", pm: "npm" },
+        ];
+
+        for (const { file, pm } of lockFiles) {
+            // Clean up any existing lock files
+            for (const { file: otherFile } of lockFiles) {
+                const path = join(testDir, otherFile);
+                if (existsSync(path)) {
+                    unlinkSync(path);
+                }
+            }
+
+            // Create the specific lock file
+            writeFileSync(join(testDir, file), "");
+            expect(existsSync(join(testDir, file))).toBe(true);
+
+            // The package manager detection logic should identify this PM
+            // This would be tested by the actual detectPackageManager function
+        }
+    });
+
+    test("migrate command script execution simulation", () => {
+        // Create a project setup
+        const projectConfig = {
+            name: "test-app",
+            database: "d1",
+            template: "hono",
+        };
+
+        writeFileSync(join(testDir, "project.config.json"), JSON.stringify(projectConfig, null, 2));
+
+        // Simulate the script execution order
+        const executionOrder: string[] = [];
+
+        // Simulate auth:update
+        executionOrder.push("auth:update");
+        expect(executionOrder[0]).toBe("auth:update");
+
+        // Simulate db:generate
+        executionOrder.push("db:generate");
+        expect(executionOrder[1]).toBe("db:generate");
+
+        // Simulate conditional db:migrate (would depend on user choice)
+        const migrateTarget = "dev"; // This would come from CLI args or user input
+        if (migrateTarget === "dev") {
+            executionOrder.push("db:migrate:dev");
+        } else if (migrateTarget === "remote") {
+            executionOrder.push("db:migrate:prod");
+        }
+
+        expect(executionOrder).toHaveLength(3);
+        expect(executionOrder[2]).toBe("db:migrate:dev");
+    });
+
+    test("migrate command handles missing package.json", () => {
+        // Create project.config.json but no package.json
+        const projectConfig = {
+            name: "test-app",
+            database: "d1",
+            template: "hono",
+        };
+
+        writeFileSync(join(testDir, "project.config.json"), JSON.stringify(projectConfig, null, 2));
+
+        expect(existsSync(join(testDir, "project.config.json"))).toBe(true);
+        expect(existsSync(join(testDir, "package.json"))).toBe(false);
+
+        // The migrate command should handle missing package.json gracefully
+        // This would be tested in actual CLI execution
+    });
+
+    test("migrate command working directory validation", () => {
+        // Test that migrate command works from project root
+        // Use realpath comparison to handle symlinks and /private prefix on macOS
+        const realCwd = require("fs").realpathSync(process.cwd());
+        const realTestDir = require("fs").realpathSync(testDir);
+        expect(realCwd).toBe(realTestDir);
+
+        // Create a project config to simulate being in a project directory
+        const projectConfig = {
+            name: "test-app",
+            database: "d1",
+        };
+
+        writeFileSync(join(testDir, "project.config.json"), JSON.stringify(projectConfig, null, 2));
+
+        // Should be able to find project.config.json in current directory
+        expect(existsSync(join(process.cwd(), "project.config.json"))).toBe(true);
+    });
+
+    test("migrate command with different database types shows appropriate messages", () => {
+        const databaseTypes = [
+            { type: "d1", shouldOfferMigration: true },
+            { type: "hyperdrive-postgres", shouldOfferMigration: false },
+            { type: "hyperdrive-mysql", shouldOfferMigration: false },
+        ];
+
+        for (const { type, shouldOfferMigration } of databaseTypes) {
+            const projectConfig = {
+                name: "test-app",
+                database: type,
+                template: "hono",
+            };
+
+            // For D1, should offer migration options
+            if (shouldOfferMigration) {
+                expect(type).toBe("d1");
+                // Would show migration options
+            } else {
+                // For non-D1, should show informational message
+                expect(["hyperdrive-postgres", "hyperdrive-mysql"]).toContain(type);
+                // Would show: "Database type is X. Please apply migrations..."
+            }
+        }
+    });
+});

--- a/cli/tests/non-interactive-args.test.ts
+++ b/cli/tests/non-interactive-args.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, test } from "bun:test";
+
+// Import helper functions that would be exposed from the main CLI module
+// Since these are internal functions, we'll test the logic here directly
+
+interface CliArgs {
+    [key: string]: string | boolean | undefined;
+}
+
+function parseCliArgs(argv: string[]): CliArgs {
+    const args: CliArgs = {};
+
+    for (let i = 2; i < argv.length; i++) {
+        const arg = argv[i];
+
+        // Handle --key=value format
+        if (arg.startsWith("--") && arg.includes("=")) {
+            const [key, ...valueParts] = arg.slice(2).split("=");
+            const value = valueParts.join("="); // Handle values that contain "="
+
+            // Convert boolean strings
+            if (value === "true") {
+                args[key] = true;
+            } else if (value === "false") {
+                args[key] = false;
+            } else {
+                args[key] = value;
+            }
+        }
+        // Handle --key value format
+        else if (arg.startsWith("--") && i + 1 < argv.length && !argv[i + 1].startsWith("--")) {
+            const key = arg.slice(2);
+            const value = argv[i + 1];
+
+            // Convert boolean strings
+            if (value === "true") {
+                args[key] = true;
+            } else if (value === "false") {
+                args[key] = false;
+            } else {
+                args[key] = value;
+            }
+            i += 1; // Skip the next argument as it's the value
+        }
+        // Handle boolean flags like --geolocation (defaults to true)
+        else if (arg.startsWith("--")) {
+            const key = arg.slice(2);
+            args[key] = true;
+        }
+    }
+
+    return args;
+}
+
+function validateBindingName(name: string): string | undefined {
+    if (!name || name.trim().length === 0) return "Please enter a binding name";
+    if (!/^[A-Z0-9_]+$/.test(name)) return "Use ONLY A-Z, 0-9, and underscores";
+    return undefined;
+}
+
+function validateCliArgs(args: CliArgs): string[] {
+    const errors: string[] = [];
+
+    // Validate app name
+    if (args["app-name"] && typeof args["app-name"] === "string") {
+        const name = args["app-name"];
+        if (!name.trim()) {
+            errors.push("app-name cannot be empty");
+        } else if (!/^[a-z0-9-]+$/.test(name)) {
+            errors.push("app-name must contain only lowercase letters, numbers, and hyphens");
+        }
+    }
+
+    // Validate template
+    if (args.template && !["hono", "nextjs"].includes(args.template as string)) {
+        errors.push("template must be 'hono' or 'nextjs'");
+    }
+
+    // Validate database
+    if (args.database && !["d1", "hyperdrive-postgres", "hyperdrive-mysql"].includes(args.database as string)) {
+        errors.push("database must be 'd1', 'hyperdrive-postgres', or 'hyperdrive-mysql'");
+    }
+
+    // Validate binding names
+    const bindingFields = ["d1-binding", "hd-binding", "kv-binding", "r2-binding"];
+    for (const field of bindingFields) {
+        if (args[field] !== undefined && typeof args[field] === "string") {
+            const error = validateBindingName(String(args[field]));
+            if (error) {
+                errors.push(`${field}: ${error}`);
+            }
+        }
+    }
+
+    // Validate connection string format if provided
+    if (args["hd-connection-string"] && typeof args["hd-connection-string"] === "string") {
+        const connStr = args["hd-connection-string"];
+        if (
+            !connStr.startsWith("postgres://") &&
+            !connStr.startsWith("postgresql://") &&
+            !connStr.startsWith("mysql://")
+        ) {
+            errors.push(
+                "hd-connection-string must be a valid database URL starting with postgres://, postgresql://, or mysql://"
+            );
+        }
+    }
+
+    return errors;
+}
+
+describe("CLI Argument Parsing", () => {
+    test("parses --key=value format", () => {
+        const argv = ["node", "cli", "--app-name=my-app", "--template=hono", "--database=d1"];
+        const args = parseCliArgs(argv);
+
+        expect(args["app-name"]).toBe("my-app");
+        expect(args.template).toBe("hono");
+        expect(args.database).toBe("d1");
+    });
+
+    test("parses --key value format", () => {
+        const argv = ["node", "cli", "--app-name", "my-app", "--template", "nextjs"];
+        const args = parseCliArgs(argv);
+
+        expect(args["app-name"]).toBe("my-app");
+        expect(args.template).toBe("nextjs");
+    });
+
+    test("parses boolean values correctly", () => {
+        const argv = ["node", "cli", "--geolocation=true", "--kv=false", "--r2"];
+        const args = parseCliArgs(argv);
+
+        expect(args.geolocation).toBe(true);
+        expect(args.kv).toBe(false);
+        expect(args.r2).toBe(true); // flag defaults to true
+    });
+
+    test("handles values with equals signs", () => {
+        const argv = ["node", "cli", "--hd-connection-string=postgres://user:pass=word@host:5432/db"];
+        const args = parseCliArgs(argv);
+
+        expect(args["hd-connection-string"]).toBe("postgres://user:pass=word@host:5432/db");
+    });
+
+    test("handles mixed argument formats", () => {
+        const argv = ["node", "cli", "--app-name=my-mixed-app", "--template", "hono", "--geolocation=false", "--kv"];
+        const args = parseCliArgs(argv);
+
+        expect(args["app-name"]).toBe("my-mixed-app");
+        expect(args.template).toBe("hono");
+        expect(args.geolocation).toBe(false);
+        expect(args.kv).toBe(true);
+    });
+
+    test("ignores non-argument parameters", () => {
+        const argv = ["node", "cli", "generate", "--app-name=test", "some-other-param"];
+        const args = parseCliArgs(argv);
+
+        expect(args["app-name"]).toBe("test");
+        expect(Object.keys(args)).toHaveLength(1);
+    });
+});
+
+describe("CLI Argument Validation", () => {
+    test("validates app name format", () => {
+        const validArgs = { "app-name": "my-valid-app-123" };
+        const invalidArgs1 = { "app-name": "My-Invalid-App" }; // uppercase
+        const invalidArgs2 = { "app-name": "my_invalid_app" }; // underscore
+        const invalidArgs3 = { "app-name": "   " }; // empty/whitespace
+
+        expect(validateCliArgs(validArgs)).toHaveLength(0);
+        expect(validateCliArgs(invalidArgs1)).toContain(
+            "app-name must contain only lowercase letters, numbers, and hyphens"
+        );
+        expect(validateCliArgs(invalidArgs2)).toContain(
+            "app-name must contain only lowercase letters, numbers, and hyphens"
+        );
+        expect(validateCliArgs(invalidArgs3)).toContain("app-name cannot be empty");
+    });
+
+    test("validates template values", () => {
+        const validArgs1 = { template: "hono" };
+        const validArgs2 = { template: "nextjs" };
+        const invalidArgs = { template: "invalid-template" };
+
+        expect(validateCliArgs(validArgs1)).toHaveLength(0);
+        expect(validateCliArgs(validArgs2)).toHaveLength(0);
+        expect(validateCliArgs(invalidArgs)).toContain("template must be 'hono' or 'nextjs'");
+    });
+
+    test("validates database values", () => {
+        const validArgs1 = { database: "d1" };
+        const validArgs2 = { database: "hyperdrive-postgres" };
+        const validArgs3 = { database: "hyperdrive-mysql" };
+        const invalidArgs = { database: "mongodb" };
+
+        expect(validateCliArgs(validArgs1)).toHaveLength(0);
+        expect(validateCliArgs(validArgs2)).toHaveLength(0);
+        expect(validateCliArgs(validArgs3)).toHaveLength(0);
+        expect(validateCliArgs(invalidArgs)).toContain(
+            "database must be 'd1', 'hyperdrive-postgres', or 'hyperdrive-mysql'"
+        );
+    });
+
+    test("validates binding names", () => {
+        const validArgs = { "d1-binding": "MY_DATABASE_123" };
+        const invalidArgs1 = { "kv-binding": "my-binding" }; // lowercase
+        const invalidArgs2 = { "r2-binding": "MY-BINDING-WITH-HYPHENS" }; // hyphens
+        const invalidArgs3 = { "hd-binding": "" }; // empty
+
+        expect(validateCliArgs(validArgs)).toHaveLength(0);
+
+        const errors1 = validateCliArgs(invalidArgs1);
+        expect(errors1.length).toBeGreaterThan(0);
+        expect(errors1[0]).toContain("Use ONLY A-Z, 0-9, and underscores");
+
+        const errors2 = validateCliArgs(invalidArgs2);
+        expect(errors2.length).toBeGreaterThan(0);
+        expect(errors2[0]).toContain("Use ONLY A-Z, 0-9, and underscores");
+
+        const errors3 = validateCliArgs(invalidArgs3);
+        expect(errors3.length).toBeGreaterThan(0);
+        expect(errors3[0]).toContain("Please enter a binding name");
+    });
+
+    test("validates connection strings", () => {
+        const validArgs1 = { "hd-connection-string": "postgres://user:pass@host:5432/db" };
+        const validArgs2 = { "hd-connection-string": "postgresql://user:pass@host:5432/db" };
+        const validArgs3 = { "hd-connection-string": "mysql://user:pass@host:3306/db" };
+        const invalidArgs = { "hd-connection-string": "invalid://connection/string" };
+
+        expect(validateCliArgs(validArgs1)).toHaveLength(0);
+        expect(validateCliArgs(validArgs2)).toHaveLength(0);
+        expect(validateCliArgs(validArgs3)).toHaveLength(0);
+
+        const errors = validateCliArgs(invalidArgs);
+        expect(errors.length).toBeGreaterThan(0);
+        expect(errors[0]).toContain("hd-connection-string must be a valid database URL");
+    });
+
+    test("accumulates multiple validation errors", () => {
+        const invalidArgs = {
+            "app-name": "Invalid_Name",
+            template: "invalid",
+            database: "mongodb",
+            "d1-binding": "invalid-binding",
+        };
+
+        const errors = validateCliArgs(invalidArgs);
+        expect(errors).toHaveLength(4);
+        expect(errors.some(e => e.includes("app-name"))).toBe(true);
+        expect(errors.some(e => e.includes("template"))).toBe(true);
+        expect(errors.some(e => e.includes("database"))).toBe(true);
+        expect(errors.some(e => e.includes("d1-binding"))).toBe(true);
+    });
+});
+
+describe("Real-world CLI Usage Scenarios", () => {
+    test("basic Hono app with D1", () => {
+        const argv = ["node", "cli", "--app-name=my-hono-app", "--template=hono", "--database=d1"];
+        const args = parseCliArgs(argv);
+        const errors = validateCliArgs(args);
+
+        expect(errors).toHaveLength(0);
+        expect(args["app-name"]).toBe("my-hono-app");
+        expect(args.template).toBe("hono");
+        expect(args.database).toBe("d1");
+    });
+
+    test("Next.js app with PostgreSQL Hyperdrive", () => {
+        const argv = [
+            "node",
+            "cli",
+            "--app-name=my-next-app",
+            "--template=nextjs",
+            "--database=hyperdrive-postgres",
+            "--hd-connection-string=postgres://user:pass@host:5432/db",
+            "--hd-binding=MY_POSTGRES",
+        ];
+        const args = parseCliArgs(argv);
+        const errors = validateCliArgs(args);
+
+        expect(errors).toHaveLength(0);
+        expect(args["app-name"]).toBe("my-next-app");
+        expect(args.template).toBe("nextjs");
+        expect(args.database).toBe("hyperdrive-postgres");
+        expect(args["hd-connection-string"]).toBe("postgres://user:pass@host:5432/db");
+        expect(args["hd-binding"]).toBe("MY_POSTGRES");
+    });
+
+    test("minimal app without KV or R2", () => {
+        const argv = ["node", "cli", "--app-name=minimal-app", "--kv=false", "--r2=false", "--geolocation=false"];
+        const args = parseCliArgs(argv);
+        const errors = validateCliArgs(args);
+
+        expect(errors).toHaveLength(0);
+        expect(args["app-name"]).toBe("minimal-app");
+        expect(args.kv).toBe(false);
+        expect(args.r2).toBe(false);
+        expect(args.geolocation).toBe(false);
+    });
+
+    test("full configuration with all options", () => {
+        const argv = [
+            "node",
+            "cli",
+            "--app-name=full-featured-app",
+            "--template=nextjs",
+            "--database=hyperdrive-mysql",
+            "--hd-connection-string=mysql://user:pass@host:3306/db",
+            "--hd-name=my-hyperdrive",
+            "--hd-binding=MYSQL_DB",
+            "--geolocation=true",
+            "--kv=true",
+            "--kv-binding=SESSION_STORE",
+            "--kv-namespace-name=app-sessions",
+            "--r2=true",
+            "--r2-binding=FILE_STORAGE",
+            "--r2-bucket-name=app-uploads",
+        ];
+        const args = parseCliArgs(argv);
+        const errors = validateCliArgs(args);
+
+        expect(errors).toHaveLength(0);
+        expect(args["app-name"]).toBe("full-featured-app");
+        expect(args.template).toBe("nextjs");
+        expect(args.database).toBe("hyperdrive-mysql");
+        expect(args["hd-connection-string"]).toBe("mysql://user:pass@host:3306/db");
+        expect(args["hd-name"]).toBe("my-hyperdrive");
+        expect(args["hd-binding"]).toBe("MYSQL_DB");
+        expect(args.geolocation).toBe(true);
+        expect(args.kv).toBe(true);
+        expect(args["kv-binding"]).toBe("SESSION_STORE");
+        expect(args["kv-namespace-name"]).toBe("app-sessions");
+        expect(args.r2).toBe(true);
+        expect(args["r2-binding"]).toBe("FILE_STORAGE");
+        expect(args["r2-bucket-name"]).toBe("app-uploads");
+    });
+});
+
+describe("Edge Cases", () => {
+    test("handles empty argv", () => {
+        const argv = ["node", "cli"];
+        const args = parseCliArgs(argv);
+
+        expect(Object.keys(args)).toHaveLength(0);
+    });
+
+    test("handles single hyphen arguments (ignored)", () => {
+        const argv = ["node", "cli", "-a", "value", "--app-name=test"];
+        const args = parseCliArgs(argv);
+
+        expect(args["-a"]).toBeUndefined();
+        expect(args["app-name"]).toBe("test");
+    });
+
+    test("handles arguments without values", () => {
+        const argv = ["node", "cli", "--app-name"];
+        const args = parseCliArgs(argv);
+
+        expect(args["app-name"]).toBe(true); // treated as boolean flag
+    });
+
+    test("handles consecutive boolean flags", () => {
+        const argv = ["node", "cli", "--geolocation", "--kv", "--r2"];
+        const args = parseCliArgs(argv);
+
+        expect(args.geolocation).toBe(true);
+        expect(args.kv).toBe(true);
+        expect(args.r2).toBe(true);
+    });
+
+    test("last argument wins for duplicates", () => {
+        const argv = ["node", "cli", "--app-name=first", "--app-name=second"];
+        const args = parseCliArgs(argv);
+
+        expect(args["app-name"]).toBe("second");
+    });
+});

--- a/cli/tests/package-manager.test.ts
+++ b/cli/tests/package-manager.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+
+// Mock package manager detection and command generation
+type PackageManager = "bun" | "pnpm" | "yarn" | "npm";
+
+function detectPackageManager(): PackageManager {
+    // In real implementation, this would check for lock files, process.env, etc.
+    // For testing, we'll simulate the logic
+
+    // Check for Bun runtime first
+    try {
+        if (typeof Bun !== "undefined") {
+            return "bun";
+        }
+    } catch {}
+
+    // Check for lock files (would use fs.existsSync in real implementation)
+    const mockLockFiles = {
+        "pnpm-lock.yaml": "pnpm",
+        "yarn.lock": "yarn",
+        "package-lock.json": "npm",
+    } as const;
+
+    // For testing, simulate finding pnpm-lock.yaml
+    return "pnpm";
+}
+
+function getInstallCommand(packageManager: PackageManager): string {
+    switch (packageManager) {
+        case "bun":
+            return "bun install";
+        case "pnpm":
+            return "pnpm install";
+        case "yarn":
+            return "yarn install";
+        case "npm":
+            return "npm install";
+    }
+}
+
+function getRunCommand(packageManager: PackageManager, script: string): string {
+    switch (packageManager) {
+        case "bun":
+            return `bun run ${script}`;
+        case "pnpm":
+            return `pnpm run ${script}`;
+        case "yarn":
+            return `yarn run ${script}`;
+        case "npm":
+            return `npm run ${script}`;
+    }
+}
+
+function getAddCommand(packageManager: PackageManager, packages: string[]): string {
+    const pkgList = packages.join(" ");
+    switch (packageManager) {
+        case "bun":
+            return `bun add ${pkgList}`;
+        case "pnpm":
+            return `pnpm add ${pkgList}`;
+        case "yarn":
+            return `yarn add ${pkgList}`;
+        case "npm":
+            return `npm install ${pkgList}`;
+    }
+}
+
+function shouldUseExactVersions(packageManager: PackageManager): boolean {
+    // Some package managers prefer exact versions for certain packages
+    return packageManager === "pnpm" || packageManager === "yarn";
+}
+
+function formatDependencyVersion(version: string, packageManager: PackageManager): string {
+    if (version === "latest") {
+        return shouldUseExactVersions(packageManager) ? version : "^latest";
+    }
+    return version;
+}
+
+describe("Package manager detection", () => {
+    test("detects package manager correctly", () => {
+        const pm = detectPackageManager();
+        expect(["bun", "pnpm", "yarn", "npm"]).toContain(pm);
+    });
+
+    test("generates correct install commands", () => {
+        expect(getInstallCommand("bun")).toBe("bun install");
+        expect(getInstallCommand("pnpm")).toBe("pnpm install");
+        expect(getInstallCommand("yarn")).toBe("yarn install");
+        expect(getInstallCommand("npm")).toBe("npm install");
+    });
+
+    test("generates correct run commands", () => {
+        expect(getRunCommand("bun", "dev")).toBe("bun run dev");
+        expect(getRunCommand("pnpm", "build")).toBe("pnpm run build");
+        expect(getRunCommand("yarn", "test")).toBe("yarn run test");
+        expect(getRunCommand("npm", "deploy")).toBe("npm run deploy");
+    });
+
+    test("generates correct add commands", () => {
+        expect(getAddCommand("bun", ["postgres"])).toBe("bun add postgres");
+        expect(getAddCommand("pnpm", ["mysql2", "@types/node"])).toBe("pnpm add mysql2 @types/node");
+        expect(getAddCommand("yarn", ["drizzle-orm"])).toBe("yarn add drizzle-orm");
+        expect(getAddCommand("npm", ["better-auth-cloudflare"])).toBe("npm install better-auth-cloudflare");
+    });
+
+    test("handles version formatting", () => {
+        expect(formatDependencyVersion("^1.0.0", "npm")).toBe("^1.0.0");
+        expect(formatDependencyVersion("latest", "bun")).toBe("^latest");
+        expect(formatDependencyVersion("latest", "pnpm")).toBe("latest");
+        expect(formatDependencyVersion("latest", "yarn")).toBe("latest");
+    });
+});
+
+describe("Package manager utilities", () => {
+    test("identifies exact version preferences", () => {
+        expect(shouldUseExactVersions("bun")).toBe(false);
+        expect(shouldUseExactVersions("npm")).toBe(false);
+        expect(shouldUseExactVersions("pnpm")).toBe(true);
+        expect(shouldUseExactVersions("yarn")).toBe(true);
+    });
+
+    test("handles multiple packages in add command", () => {
+        const packages = ["postgres", "drizzle-orm", "@types/node"];
+        expect(getAddCommand("bun", packages)).toBe("bun add postgres drizzle-orm @types/node");
+        expect(getAddCommand("npm", packages)).toBe("npm install postgres drizzle-orm @types/node");
+    });
+
+    test("handles empty package list", () => {
+        expect(getAddCommand("bun", [])).toBe("bun add ");
+        expect(getAddCommand("npm", [])).toBe("npm install ");
+    });
+});

--- a/cli/tests/tsconfig.json
+++ b/cli/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["bun-types"]
+    },
+    "include": ["./**/*"]
+}

--- a/cli/tests/utility-functions.test.ts
+++ b/cli/tests/utility-functions.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { validateBindingName } from "../src/index";
+
+describe("Utility Functions", () => {
+    describe("validateBindingName", () => {
+        test("accepts valid binding names", () => {
+            const validNames = [
+                "DATABASE",
+                "MY_DATABASE",
+                "DB_123",
+                "KV",
+                "R2_BUCKET",
+                "HYPERDRIVE_DB",
+                "TEST_BINDING_NAME",
+                "A", // single character
+                "A_B_C_D_E_F_G", // long name
+                "DB2", // ends with number
+                "MY_123_DB", // mixed
+                "123VALID", // starts with number (valid!)
+                "123_DB", // starts with number (valid!)
+                "999", // all numbers
+                "A1B2C3", // mixed letters and numbers
+                "_DATABASE", // starts with underscore (valid!)
+                "DATABASE_", // ends with underscore (valid!)
+                "_", // single underscore (valid!)
+                "_123", // underscore + numbers (valid!)
+            ];
+
+            for (const name of validNames) {
+                expect(validateBindingName(name)).toBeUndefined();
+            }
+        });
+
+        test("rejects invalid binding names", () => {
+            const invalidNames = [
+                "database", // lowercase
+                "myDatabase", // camelCase
+                "my-database", // kebab-case
+                "MY DATABASE", // spaces
+                "MY_DATABASE!", // special characters
+
+                "", // empty string
+                " ", // whitespace only
+                "my.database", // dots
+                "my@database", // at symbol
+                "my#database", // hash
+                "my$database", // dollar
+                "my%database", // percent
+                "my&database", // ampersand
+                "my*database", // asterisk
+                "my+database", // plus
+                "my=database", // equals
+                "my[database]", // brackets
+                "my{database}", // braces
+                "my|database", // pipe
+                "my\\database", // backslash
+                "my/database", // forward slash
+                "my:database", // colon
+                "my;database", // semicolon
+                "my<database>", // angle brackets
+                "my,database", // comma
+                "my?database", // question mark
+                'my"database"', // quotes
+                "my'database'", // single quotes
+            ];
+
+            for (const name of invalidNames) {
+                const result = validateBindingName(name);
+                expect(result).toBeDefined();
+                // Handle different error messages
+                expect(
+                    result?.includes("A-Z, 0-9, and underscores") || result?.includes("Please enter a binding name")
+                ).toBe(true);
+            }
+        });
+
+        test("provides helpful error messages", () => {
+            expect(validateBindingName("lowercase")).toBe("Use ONLY A-Z, 0-9, and underscores");
+            expect(validateBindingName("my-binding")).toBe("Use ONLY A-Z, 0-9, and underscores");
+            expect(validateBindingName("invalid!")).toBe("Use ONLY A-Z, 0-9, and underscores");
+        });
+
+        test("handles edge cases", () => {
+            // Very long names should still be valid if they follow the pattern
+            const longValidName = "A".repeat(100);
+            expect(validateBindingName(longValidName)).toBeUndefined();
+
+            // Mixed valid characters
+            expect(validateBindingName("A1B2C3_D4E5F6")).toBeUndefined();
+
+            // Single underscore between valid parts
+            expect(validateBindingName("VALID_NAME")).toBeUndefined();
+            expect(validateBindingName("VALID_NAME_123")).toBeUndefined();
+        });
+    });
+
+    describe("Template and Database Options", () => {
+        test("supports expected template options", () => {
+            const expectedTemplates = ["hono", "nextjs"];
+            // This test ensures our CLI supports the expected templates
+            // The actual options are defined in the CLI prompts
+            expect(expectedTemplates).toContain("hono");
+            expect(expectedTemplates).toContain("nextjs");
+        });
+
+        test("supports expected database options", () => {
+            const expectedDatabases = ["d1", "hyperdrive-postgres", "hyperdrive-mysql"];
+            // This test ensures our CLI supports the expected database types
+            expect(expectedDatabases).toContain("d1");
+            expect(expectedDatabases).toContain("hyperdrive-postgres");
+            expect(expectedDatabases).toContain("hyperdrive-mysql");
+        });
+    });
+
+    describe("Default Value Patterns", () => {
+        test("follows consistent naming patterns", () => {
+            const appName = "test-app";
+
+            // Test the patterns used in the CLI
+            expect(`${appName}-db`).toBe("test-app-db");
+            expect(`${appName}-kv`).toBe("test-app-kv");
+            expect(`${appName}-files`).toBe("test-app-files");
+            expect(`${appName}-hyperdrive`).toBe("test-app-hyperdrive");
+        });
+
+        test("handles fallback values correctly", () => {
+            const fallbackApp = "my-app";
+
+            expect(`${fallbackApp}-db`).toBe("my-app-db");
+            expect(`${fallbackApp}-kv`).toBe("my-app-kv");
+            expect(`${fallbackApp}-files`).toBe("my-app-files");
+            expect(`${fallbackApp}-hyperdrive`).toBe("my-app-hyperdrive");
+        });
+    });
+});

--- a/cli/tests/wrangler-toml.test.ts
+++ b/cli/tests/wrangler-toml.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, test } from "bun:test";
+import {
+    appendOrReplaceHyperdriveBlock,
+    appendOrReplaceKvNamespaceBlock,
+    appendOrReplaceR2Block,
+    clearAllKvBlocks,
+    clearAllR2Blocks,
+    extractFirstBlock,
+    updateD1Block,
+    validateBindingName,
+} from "../src/index";
+
+const baseToml = `name = "app"
+compatibility_date = "2025-03-01"
+
+[[d1_databases]]
+binding = "DATABASE"
+database_name = "db"
+
+[[kv_namespaces]]
+binding = "KV"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "bucket"
+`;
+
+describe("validateBindingName", () => {
+    test("accepts caps, numbers, underscores", () => {
+        expect(validateBindingName("FOO_123")).toBeUndefined();
+    });
+    test("rejects lowercase", () => {
+        expect(validateBindingName("foo")).toBeTruthy();
+    });
+    test("rejects dash", () => {
+        expect(validateBindingName("BAD-NAME")).toBeTruthy();
+    });
+});
+
+describe("extractFirstBlock", () => {
+    test("finds d1 block", () => {
+        const res = extractFirstBlock(baseToml, "d1_databases");
+        expect(res?.block).toContain("[[d1_databases]]");
+    });
+    test("returns null when header not present", () => {
+        const res = extractFirstBlock(baseToml, "not_exists");
+        expect(res).toBeNull();
+    });
+});
+
+describe("updateD1Block", () => {
+    test("updates binding and database name", () => {
+        const out = updateD1Block(baseToml, "DB", "mydb");
+        expect(out).toContain('binding = "DB"');
+        expect(out).toContain('database_name = "mydb"');
+    });
+    test("no-op if no d1 block", () => {
+        const noD1 = baseToml.replace(/\[\[d1_databases\]\][\s\S]*/m, "");
+        const out = updateD1Block(noD1, "DB", "mydb");
+        expect(out).toEqual(noD1);
+    });
+});
+
+describe("appendOrReplaceKvNamespaceBlock", () => {
+    test("replaces kv block by binding", () => {
+        const out = appendOrReplaceKvNamespaceBlock(baseToml, "SESSIONS");
+        expect(out).toContain('binding = "SESSIONS"');
+    });
+    test("adds id if provided", () => {
+        const out = appendOrReplaceKvNamespaceBlock(baseToml, "SESSIONS", "123");
+        expect(out).toContain('id = "123"');
+    });
+    test("appends when no kv block exists", () => {
+        const noKv = baseToml.replace(/\[\[kv_namespaces\]\][\s\S]*?(?=(\n\[\[|$))/g, "");
+        const out = appendOrReplaceKvNamespaceBlock(noKv, "CACHE");
+        expect(out).toContain("[[kv_namespaces]]");
+        expect(out).toContain('binding = "CACHE"');
+    });
+});
+
+describe("appendOrReplaceR2Block", () => {
+    test("replaces r2 bucket binding", () => {
+        const out = appendOrReplaceR2Block(baseToml, "FILES", "my-bucket");
+        expect(out).toContain('binding = "FILES"');
+        expect(out).toContain('bucket_name = "my-bucket"');
+    });
+    test("appends when no r2 block exists", () => {
+        const noR2 = baseToml.replace(/\[\[r2_buckets\]\][\s\S]*?(?=(\n\[\[|$))/g, "");
+        const out = appendOrReplaceR2Block(noR2, "FILES", "my-bucket");
+        expect(out).toContain("[[r2_buckets]]");
+    });
+});
+
+describe("appendOrReplaceHyperdriveBlock", () => {
+    test("adds hyperdrive block", () => {
+        const out = appendOrReplaceHyperdriveBlock(baseToml, "HYPERDRIVE", "abcd");
+        expect(out).toContain("[[hyperdrive]]");
+        expect(out).toContain('binding = "HYPERDRIVE"');
+        expect(out).toContain('id = "abcd"');
+    });
+    test("replaces existing hyperdrive block", () => {
+        const first = appendOrReplaceHyperdriveBlock(baseToml, "HYPERDRIVE", "abcd");
+        const second = appendOrReplaceHyperdriveBlock(first, "HYPERDRIVE", "efgh");
+        expect(second).toContain('id = "efgh"');
+        expect(second).not.toContain('id = "abcd"');
+    });
+});
+
+describe("Wrangler.toml format validation", () => {
+    test("prevents duplicate R2 blocks with same binding", () => {
+        // Start with a toml that has an existing R2 block
+        const existingR2Toml = `name = "app"
+compatibility_date = "2025-03-01"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "existing-bucket"
+`;
+
+        // Try to add another R2 block with same binding - should replace, not duplicate
+        const result = appendOrReplaceR2Block(existingR2Toml, "R2_BUCKET", "new-bucket");
+
+        // Should only have one R2 block
+        const r2BlockCount = (result.match(/\[\[r2_buckets\]\]/g) || []).length;
+        expect(r2BlockCount).toBe(1);
+
+        // Should have the new bucket name
+        expect(result).toContain('bucket_name = "new-bucket"');
+        expect(result).not.toContain('bucket_name = "existing-bucket"');
+    });
+
+    test("prevents duplicate R2 blocks with different bindings", () => {
+        const existingR2Toml = `name = "app"
+compatibility_date = "2025-03-01"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "existing-bucket"
+`;
+
+        // Add a different R2 binding - should create new block
+        const result = appendOrReplaceR2Block(existingR2Toml, "R2_FILES", "files-bucket");
+
+        // Should have two R2 blocks
+        const r2BlockCount = (result.match(/\[\[r2_buckets\]\]/g) || []).length;
+        expect(r2BlockCount).toBe(2);
+
+        // Should have both bucket names
+        expect(result).toContain('bucket_name = "existing-bucket"');
+        expect(result).toContain('bucket_name = "files-bucket"');
+    });
+
+    test("KV namespace requires id field", () => {
+        const kvBlock = appendOrReplaceKvNamespaceBlock(baseToml, "KV", "test-kv-id");
+
+        // Must have both binding and id
+        expect(kvBlock).toContain('binding = "KV"');
+        expect(kvBlock).toContain('id = "test-kv-id"');
+
+        // Should not create invalid KV block without id
+        const invalidKvBlock = appendOrReplaceKvNamespaceBlock(baseToml, "KV");
+        expect(invalidKvBlock).toContain('binding = "KV"');
+        // When no id provided, should not add id field (this would be invalid for actual wrangler)
+    });
+
+    test("validates complete CLI-generated wrangler.toml format", () => {
+        let toml = `name = "my-app"
+compatibility_date = "2025-03-01"
+
+[[d1_databases]]
+binding = "DATABASE"
+database_name = "placeholder"
+database_id = "placeholder"
+migrations_dir = "drizzle"
+`;
+
+        // Apply all CLI transformations
+        toml = updateD1Block(toml, "DATABASE", "my-app-db");
+        toml = appendOrReplaceKvNamespaceBlock(toml, "KV", "kv-id-123");
+        toml = appendOrReplaceR2Block(toml, "R2", "my-app-files");
+
+        // Verify final format
+        expect(toml).toContain('database_name = "my-app-db"');
+        expect(toml).toContain('binding = "KV"');
+        expect(toml).toContain('id = "kv-id-123"');
+        expect(toml).toContain('binding = "R2"');
+        expect(toml).toContain('bucket_name = "my-app-files"');
+
+        // Ensure no duplicate blocks
+        expect((toml.match(/\[\[d1_databases\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[kv_namespaces\]\]/g) || []).length).toBe(1);
+        expect((toml.match(/\[\[r2_buckets\]\]/g) || []).length).toBe(1);
+    });
+
+    test("reproduces CLI duplicate R2 block issue", () => {
+        // This reproduces the exact issue from the CLI generation
+        const templateToml = `# For more details on how to configure Wrangler, refer to:
+# https://developers.cloudflare.com/workers/wrangler/configuration/
+
+name = "better-auth-cloudflare"
+main = ".open-next/worker.js"
+compatibility_date = "2025-03-01"
+compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
+
+[assets]
+binding = "ASSETS"
+directory = ".open-next/assets"
+
+[observability]
+enabled = true
+
+[placement]
+mode = "smart"
+
+[[d1_databases]]
+binding = "DATABASE"
+database_name = "better-auth-cloudflare-db"
+database_id = "abd74206-37a2-4233-9813-cda1473be8f9"
+migrations_dir = "drizzle"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "cfa2f71dcfff43ffaab4c093968f6347"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "better-auth-cloudflare-files"
+`;
+
+        // User chooses different R2 binding "R2" instead of "R2_BUCKET"
+        // Use the CLI's approach: clear existing blocks then add new one
+        let result = clearAllR2Blocks(templateToml);
+        result = appendOrReplaceR2Block(result, "R2", "my-app-files");
+
+        // Should have exactly one R2 block
+        const r2BlockCount = (result.match(/\[\[r2_buckets\]\]/g) || []).length;
+        expect(r2BlockCount).toBe(1);
+
+        // Should only have the new binding, not the old one
+        expect(result).toContain('binding = "R2"');
+        expect(result).toContain('bucket_name = "my-app-files"');
+        expect(result).not.toContain('binding = "R2_BUCKET"');
+        expect(result).not.toContain('bucket_name = "better-auth-cloudflare-files"');
+    });
+});
+
+describe("Clear functions", () => {
+    test("clearAllR2Blocks removes all R2 bucket configurations", () => {
+        const tomlWithMultipleR2 = `name = "app"
+
+[[r2_buckets]]
+binding = "R2_BUCKET"
+bucket_name = "bucket1"
+
+[[r2_buckets]]  
+binding = "FILES"
+bucket_name = "bucket2"
+
+[[d1_databases]]
+binding = "DATABASE"
+`;
+
+        const result = clearAllR2Blocks(tomlWithMultipleR2);
+
+        expect(result).not.toContain("[[r2_buckets]]");
+        expect(result).not.toContain('binding = "R2_BUCKET"');
+        expect(result).not.toContain('binding = "FILES"');
+        // Should preserve other blocks
+        expect(result).toContain("[[d1_databases]]");
+    });
+
+    test("clearAllKvBlocks removes all KV namespace configurations", () => {
+        const tomlWithMultipleKv = `name = "app"
+
+[[kv_namespaces]]
+binding = "KV"
+id = "id1"
+
+[[kv_namespaces]]
+binding = "CACHE"
+id = "id2"
+
+[[d1_databases]]
+binding = "DATABASE"
+`;
+
+        const result = clearAllKvBlocks(tomlWithMultipleKv);
+
+        expect(result).not.toContain("[[kv_namespaces]]");
+        expect(result).not.toContain('binding = "KV"');
+        expect(result).not.toContain('binding = "CACHE"');
+        // Should preserve other blocks
+        expect(result).toContain("[[d1_databases]]");
+    });
+});

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "CommonJS",
+        "moduleResolution": "Node",
+        "outDir": "dist",
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "sourceMap": true,
+        "types": ["bun-types"]
+    },
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
Adds a new CLI tool to simplify creating new projects that use `better-auth-cloudflare` and managing your schema and migrations as your project scales or you choose to add new BetterAuth plugins. 

**Interactive mode** will walk you through each step, setup the local project, and initialize the Cloudflare resources for you. Or you can supply arguments to initialize it more programmatically. 

## Generating new projects
```
npx @better-auth-cloudflare/cli generate
```
## Migrating after extending the `user` schema in my `auth.ts` file:

Handle generating the drizzle schema and the migration to local or production database:
```
npx @better-auth-cloudflare/cli migrate
```
