### PR TITLE
After a successful upload, the generateId is no return

### DIFF
--- a/src/r2.ts
+++ b/src/r2.ts
@@ -649,10 +649,13 @@ export const createR2Endpoints = (
 
                     // Store file metadata in database
                     try {
-                        await ctx.context.adapter.create({
+                        const newFile = await ctx.context.adapter.create({
                             model: modelName,
                             data: {
-                                id: fileMetadata.id,
+                                // You are trying to create a record with an id. 
+                                // This is not allowed as we handle id generation for you. 
+                                // The id will be ignored.
+                                // id: fileMetadata.id,
                                 userId: fileMetadata.userId,
                                 filename: fileMetadata.filename,
                                 originalName: fileMetadata.originalName,
@@ -664,7 +667,7 @@ export const createR2Endpoints = (
                             },
                         });
 
-                        ctx.context.logger?.info("[R2]: File metadata saved to database:", fileMetadata.id);
+                        ctx.context.logger?.info("[R2]: File metadata saved to database:", newFile.id);
                     } catch (dbError) {
                         ctx.context.logger?.error("[R2]: Failed to save to database:", dbError);
 
@@ -682,7 +685,7 @@ export const createR2Endpoints = (
 
                     return ctx.json({
                         success: true,
-                        data: fileMetadata,
+                        data: { ...fileMetadata, id: newFile.id },
                     });
                 } catch (error) {
                     ctx.context.logger?.error("[R2]: Upload failed:", error);

--- a/src/r2.ts
+++ b/src/r2.ts
@@ -121,7 +121,7 @@ function convertFieldAttributesToZodSchema(additionalFields: Record<string, DBFi
 // Zod schemas for validation
 export const createFileMetadataSchema = (additionalFields?: Record<string, DBFieldAttribute>) => {
     if (!additionalFields || Object.keys(additionalFields).length === 0) {
-        return z.record(z.string(), z.any()).optional();
+        return z.object({}).optional();
     }
     return convertFieldAttributesToZodSchema(additionalFields).optional();
 };
@@ -336,6 +336,7 @@ export const createR2Storage = (
 
                 // Create metadata for callbacks
                 const metadata: FileMetadata = {
+                    ...validatedMetadata,
                     id: fileId,
                     userId,
                     filename,
@@ -344,7 +345,6 @@ export const createR2Storage = (
                     size: file.size,
                     r2Key,
                     uploadedAt: new Date(),
-                    ...validatedMetadata,
                 };
 
                 // Call beforeUpload hook
@@ -649,21 +649,9 @@ export const createR2Endpoints = (
 
                     // Store file metadata in database
                     try {
-                        const newFile = await ctx.context.adapter.create({
-                            model: modelName,
-                            data: {
-                                userId: fileMetadata.userId,
-                                filename: fileMetadata.filename,
-                                originalName: fileMetadata.originalName,
-                                contentType: fileMetadata.contentType,
-                                size: fileMetadata.size,
-                                r2Key: fileMetadata.r2Key,
-                                uploadedAt: fileMetadata.uploadedAt,
-                                ...customMetadata,
-                            },
-                        });
+                        await ctx.context.adapter.create({ model: modelName, forceAllowId: true, data: fileMetadata });
 
-                        ctx.context.logger?.info("[R2]: File metadata saved to database:", newFile.id);
+                        ctx.context.logger?.info("[R2]: File metadata saved to database:", fileMetadata.id);
                     } catch (dbError) {
                         ctx.context.logger?.error("[R2]: Failed to save to database:", dbError);
 
@@ -681,7 +669,7 @@ export const createR2Endpoints = (
 
                     return ctx.json({
                         success: true,
-                        data: { ...fileMetadata, id: newFile.id },
+                        data: fileMetadata,
                     });
                 } catch (error) {
                     ctx.context.logger?.error("[R2]: Upload failed:", error);

--- a/src/r2.ts
+++ b/src/r2.ts
@@ -652,10 +652,6 @@ export const createR2Endpoints = (
                         const newFile = await ctx.context.adapter.create({
                             model: modelName,
                             data: {
-                                // You are trying to create a record with an id. 
-                                // This is not allowed as we handle id generation for you. 
-                                // The id will be ignored.
-                                // id: fileMetadata.id,
                                 userId: fileMetadata.userId,
                                 filename: fileMetadata.filename,
                                 originalName: fileMetadata.originalName,

--- a/test/r2-upload.test.mjs
+++ b/test/r2-upload.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+import { withCloudflare } from "../dist/index.mjs";
+
+const origin = "http://localhost";
+const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function createBucket() {
+    const objects = new Map();
+    return {
+        async put(key, body) {
+            objects.set(key, body);
+            return { key };
+        },
+        async get(key) {
+            const body = objects.get(key);
+            return body ? { body: new Blob([body]).stream() } : null;
+        },
+        async delete(key) {
+            objects.delete(key);
+        },
+    };
+}
+
+function call(auth, path, init, cookie) {
+    return auth.handler(
+        new Request(`${origin}/api/auth${path}`, {
+            method: "POST",
+            ...init,
+            headers: { origin, ...(cookie ? { cookie } : {}), ...init.headers },
+        })
+    );
+}
+
+describe("R2 upload", () => {
+    it("returns the id the file is stored under", async () => {
+        const auth = betterAuth({
+            baseURL: origin,
+            secret: "r2-upload-test-secret-at-least-32-chars",
+            emailAndPassword: { enabled: true },
+            ...withCloudflare(
+                {
+                    autoDetectIpAddress: false,
+                    geolocationTracking: false,
+                    r2: { bucket: createBucket(), allowedTypes: [".png"] },
+                },
+                { database: memoryAdapter({ user: [], session: [], account: [], verification: [], userFile: [] }) }
+            ),
+        });
+
+        const signUp = await call(auth, "/sign-up/email", {
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ name: "Ada", email: "ada@example.com", password: "correct-horse-battery" }),
+        });
+        assert.equal(signUp.status, 200);
+        const setCookie = signUp.headers.get("set-cookie");
+        assert.ok(setCookie);
+        const cookie = setCookie.split(";")[0];
+        const { user } = await signUp.json();
+
+        const upload = await call(
+            auth,
+            "/files/upload-raw",
+            {
+                headers: {
+                    "content-type": "image/png",
+                    "x-filename": "probe.png",
+                    "x-file-metadata": JSON.stringify({ id: "forged", userId: "someone-else" }),
+                },
+                body: png,
+            },
+            cookie
+        );
+        assert.equal(upload.status, 200);
+        const { data } = await upload.json();
+        assert.notEqual(data.id, "forged");
+        assert.equal(data.userId, user.id);
+
+        const list = await call(auth, "/files/list", { method: "GET" }, cookie);
+        const { files } = await list.json();
+        assert.equal(files.length, 1);
+        assert.equal(files[0].id, data.id);
+        assert.equal(files[0].userId, user.id);
+
+        const download = await call(
+            auth,
+            "/files/download",
+            { headers: { "content-type": "application/json" }, body: JSON.stringify({ fileId: data.id }) },
+            cookie
+        );
+        assert.equal(download.status, 200);
+        assert.equal(download.headers.get("content-type"), "image/png");
+        assert.deepEqual(new Uint8Array(await download.arrayBuffer()), png);
+    });
+});


### PR DESCRIPTION
Removed the manual setting of id when creating records via the Drizzle Adapter to prevent the following warning:

<img width="1738" height="322" alt="ScreenShot_2025-11-11_220437_041" src="https://github.com/user-attachments/assets/7f019c9f-737f-49fb-b521-84958fd593c6" />