### PR TITLE
refactor: use generic constraints to fix `@cloudflare/workers-types` version conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
         "zod": "^4.1.5"
     },
     "peerDependencies": {
-        "better-auth": "^1.1.21"
+        "better-auth": "^1.1.21",
+        "@cloudflare/workers-types": "^4"
     },
     "devDependencies": {
         "@cloudflare/workers-types": "4.20250606.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,10 @@
-import type { KVNamespace } from "@cloudflare/workers-types";
 import { type BetterAuthOptions, type BetterAuthPlugin, type Session } from "better-auth";
 import { type SecondaryStorage } from "better-auth/db";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { createAuthEndpoint, getSessionFromCtx } from "better-auth/api";
 import { schema } from "./schema";
 import { createR2Storage, createR2Endpoints } from "./r2";
-import type { CloudflareGeolocation, CloudflarePluginOptions, WithCloudflareOptions } from "./types";
+import type { CloudflareGeolocation, CloudflarePluginOptions, WithCloudflareOptions, KVNamespaceConstraint, R2BucketConstraint } from "./types";
 export * from "./client";
 export * from "./schema";
 export * from "./types";
@@ -17,7 +16,9 @@ export * from "./r2";
  * @param options - Plugin configuration options
  * @returns Better Auth plugin for Cloudflare
  */
-export const cloudflare = (options?: CloudflarePluginOptions) => {
+export const cloudflare = <TR2 extends R2BucketConstraint = R2BucketConstraint>(
+    options?: CloudflarePluginOptions<TR2>
+) => {
     const opts = options ?? {};
 
     // Default geolocationTracking to true if not specified
@@ -117,7 +118,7 @@ function extractGeolocationData(input: CloudflareGeolocation): CloudflareGeoloca
  * @param kv - Cloudflare KV namespace
  * @returns SecondaryStorage implementation
  */
-export const createKVStorage = (kv: KVNamespace<string>): SecondaryStorage => {
+export const createKVStorage = (kv: KVNamespaceConstraint): SecondaryStorage => {
     return {
         get: async (key: string) => {
             return kv.get(key);
@@ -141,13 +142,6 @@ export const createKVStorage = (kv: KVNamespace<string>): SecondaryStorage => {
 };
 
 /**
- * Type helper to infer the enhanced auth type with Cloudflare plugin
- */
-type WithCloudflareAuth<T extends BetterAuthOptions> = T & {
-    plugins: [ReturnType<typeof cloudflare>, ...(T["plugins"] extends readonly any[] ? T["plugins"] : [])];
-};
-
-/**
  * Enhances BetterAuthOptions with Cloudflare-specific configurations.
  *
  * This function integrates Cloudflare services like D1 for database and KV for secondary storage,
@@ -157,10 +151,14 @@ type WithCloudflareAuth<T extends BetterAuthOptions> = T & {
  * @param options - The base BetterAuthOptions to be enhanced.
  * @returns BetterAuthOptions configured for use with Cloudflare.
  */
-export const withCloudflare = <T extends BetterAuthOptions>(
-    cloudFlareOptions: WithCloudflareOptions,
+export const withCloudflare = <
+    TKV extends KVNamespaceConstraint = KVNamespaceConstraint,
+    TR2 extends R2BucketConstraint = R2BucketConstraint,
+    T extends BetterAuthOptions = BetterAuthOptions
+>(
+    cloudFlareOptions: WithCloudflareOptions<TKV, TR2>,
     options: T
-): WithCloudflareAuth<T> => {
+) => {
     const autoDetectIpEnabled =
         cloudFlareOptions.autoDetectIpAddress === undefined || cloudFlareOptions.autoDetectIpAddress === true;
     const geolocationTrackingForSession =
@@ -222,15 +220,14 @@ export const withCloudflare = <T extends BetterAuthOptions>(
             ...cloudFlareOptions.d1.options,
         });
     }
-
     return {
         ...options,
         database,
         secondaryStorage: cloudFlareOptions.kv ? createKVStorage(cloudFlareOptions.kv) : undefined,
-        plugins: [cloudflare(cloudFlareOptions), ...(options.plugins ?? [])],
+        plugins: [cloudflare<TR2>(cloudFlareOptions), ...(options.plugins ?? [])],
         advanced: updatedAdvanced,
         session: updatedSession,
-    } as WithCloudflareAuth<T>;
+    };
 };
 
 export type SessionWithGeolocation = Session & CloudflareGeolocation;

--- a/src/types.ts
+++ b/src/types.ts
@@ -285,12 +285,12 @@ export interface R2Config<TR2 extends R2BucketConstraint = R2BucketConstraint> {
 type InferFieldType<T extends FieldAttribute> = T["type"] extends "string"
     ? string
     : T["type"] extends "number"
-    ? number
-    : T["type"] extends "boolean"
-    ? boolean
-    : T["type"] extends "date"
-    ? Date
-    : any;
+      ? number
+      : T["type"] extends "boolean"
+        ? boolean
+        : T["type"] extends "date"
+          ? Date
+          : any;
 
 // Convert Record<string, FieldAttribute> to actual typed object
 type InferAdditionalFields<T extends Record<string, FieldAttribute>> = {
@@ -320,57 +320,57 @@ export type FileMetadataWithAdditionalFields<T extends Record<string, FieldAttri
 // Infer R2Config types from runtime definition (eliminates double definition!)
 export type InferR2Config<T extends R2Config<R2BucketConstraint>> =
     T["additionalFields"] extends Record<string, FieldAttribute>
-    ? Omit<T, "hooks"> & {
-        hooks?: {
-            upload?: {
-                before?: (
-                    file: File & {
-                        userId: string;
-                        r2Key: string;
-                        metadata: FileMetadataWithAdditionalFields<T["additionalFields"]>;
-                    },
-                    ctx: AuthContext
-                ) => Promise<void | null | undefined>;
+        ? Omit<T, "hooks"> & {
+              hooks?: {
+                  upload?: {
+                      before?: (
+                          file: File & {
+                              userId: string;
+                              r2Key: string;
+                              metadata: FileMetadataWithAdditionalFields<T["additionalFields"]>;
+                          },
+                          ctx: AuthContext
+                      ) => Promise<void | null | undefined>;
 
-                after?: (
-                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                    ctx: AuthContext
-                ) => Promise<void>;
-            };
+                      after?: (
+                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                          ctx: AuthContext
+                      ) => Promise<void>;
+                  };
 
-            download?: {
-                before?: (
-                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                    ctx: AuthContext
-                ) => Promise<void | null | undefined>;
+                  download?: {
+                      before?: (
+                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                          ctx: AuthContext
+                      ) => Promise<void | null | undefined>;
 
-                after?: (
-                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                    ctx: AuthContext
-                ) => Promise<void>;
-            };
+                      after?: (
+                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                          ctx: AuthContext
+                      ) => Promise<void>;
+                  };
 
-            delete?: {
-                before?: (
-                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                    ctx: AuthContext
-                ) => Promise<void | null | undefined>;
+                  delete?: {
+                      before?: (
+                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                          ctx: AuthContext
+                      ) => Promise<void | null | undefined>;
 
-                after?: (
-                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                    ctx: AuthContext
-                ) => Promise<void>;
-            };
+                      after?: (
+                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                          ctx: AuthContext
+                      ) => Promise<void>;
+                  };
 
-            list?: {
-                before?: (userId: string, ctx: AuthContext) => Promise<void | null | undefined>;
+                  list?: {
+                      before?: (userId: string, ctx: AuthContext) => Promise<void | null | undefined>;
 
-                after?: (userId: string, files: any, ctx: AuthContext) => Promise<void>;
-            };
-        };
-    }
-    : T;
-
+                      after?: (userId: string, files: any, ctx: AuthContext) => Promise<void>;
+                  };
+              };
+          }
+        : T;
+        
 /**
  * Helper to create a fully typed R2 config with automatic type inference
  *

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,16 +114,7 @@ export interface WithCloudflareOptions<
 /**
  * Cloudflare geolocation data
  */
-export interface CloudflareGeolocation {
-    timezone?: string | null;
-    city?: string | null;
-    country?: string | null;
-    region?: string | null;
-    regionCode?: string | null;
-    colo?: string | null;
-    latitude?: string | null;
-    longitude?: string | null;
-}
+export interface CloudflareGeolocation extends Partial<IncomingRequestCfProperties> { }
 
 /**
  * Session type enhanced with Cloudflare geolocation data

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import type { KVNamespace } from "@cloudflare/workers-types";
 import type { AuthContext, Session, User } from "better-auth";
 import type { DrizzleAdapterConfig } from "better-auth/adapters/drizzle";
 import type { FieldAttribute } from "better-auth/db";
@@ -6,7 +5,33 @@ import type { drizzle as d1Drizzle } from "drizzle-orm/d1";
 import type { drizzle as mysqlDrizzle } from "drizzle-orm/mysql2";
 import type { drizzle as postgresDrizzle } from "drizzle-orm/postgres-js";
 
-export interface CloudflarePluginOptions {
+/**
+ * Minimal KV interface constraint - defines what methods we actually use
+ * Any KVNamespace from @cloudflare/workers-types will satisfy this constraint
+ */
+export interface KVNamespaceConstraint {
+    get(key: string, options?: { type?: "text"; cacheTtl?: number }): Promise<string | null>;
+    put(
+        key: string,
+        value: string | ArrayBuffer | ArrayBufferView | ReadableStream,
+        options?: { expiration?: number; expirationTtl?: number; metadata?: unknown }
+    ): Promise<void>;
+    delete(key: string): Promise<void>;
+}
+
+/**
+ * Minimal R2 bucket interface constraint - defines what methods we actually use
+ * Any R2Bucket from @cloudflare/workers-types will satisfy this constraint
+ */
+export interface R2BucketConstraint {
+    put(key: string, value: Blob | ReadableStream | ArrayBuffer | ArrayBufferView | string, options?: unknown): Promise<unknown>;
+    get(key: string, options?: unknown): Promise<{ body: ReadableStream } | null>;
+    delete(key: string | string[]): Promise<void>;
+    head(key: string): Promise<unknown>;
+    list(options?: { limit?: number; prefix?: string; cursor?: string }): Promise<{ objects: unknown[] }>;
+}
+
+export interface CloudflarePluginOptions<TR2 extends R2BucketConstraint = R2BucketConstraint> {
     /**
      * Auto-detect IP address
      * @default true
@@ -28,7 +53,7 @@ export interface CloudflarePluginOptions {
      * R2 configuration for user file tracking
      * If provided, enables file tracking features automatically
      */
-    r2?: R2Config;
+    r2?: R2Config<TR2>;
 }
 
 /**
@@ -45,7 +70,25 @@ export type DrizzleConfig<T extends typeof d1Drizzle | typeof postgresDrizzle | 
     options?: Omit<DrizzleAdapterConfig, "provider">;
 };
 
-export interface WithCloudflareOptions extends CloudflarePluginOptions {
+/**
+ * Options for withCloudflare wrapper
+ *
+ * @typeParam TKV - Your KVNamespace type from @cloudflare/workers-types (optional, auto-inferred)
+ * @typeParam TR2 - Your R2Bucket type from @cloudflare/workers-types (optional, auto-inferred)
+ *
+ * @example
+ * ```ts
+ * // Types are automatically inferred from your platform.env types
+ * withCloudflare({
+ *   kv: platform.env.MY_KV,  // TKV is inferred
+ *   r2: { bucket: platform.env.MY_R2 }  // TR2 is inferred
+ * }, { ... })
+ * ```
+ */
+export interface WithCloudflareOptions<
+    TKV extends KVNamespaceConstraint = KVNamespaceConstraint,
+    TR2 extends R2BucketConstraint = R2BucketConstraint
+> extends CloudflarePluginOptions<TR2> {
     /**
      * D1 database configuration for SQLite
      */
@@ -63,8 +106,9 @@ export interface WithCloudflareOptions extends CloudflarePluginOptions {
 
     /**
      * KV namespace for secondary storage, if you want to use that.
+     * Pass your KVNamespace directly - types will be inferred from your @cloudflare/workers-types.
      */
-    kv?: KVNamespace<string>;
+    kv?: TKV;
 }
 
 /**
@@ -104,17 +148,7 @@ export interface CloudflareSessionResponse {
     user: User;
 }
 
-/**
- * Minimal R2Bucket interface - only what we actually need for file storage
- * Avoids complex type conflicts between DOM and Cloudflare Worker types
- */
-export interface R2Bucket {
-    put(key: string, value: Blob | File, options?: any): Promise<any>;
-    get(key: string): Promise<{ body: ReadableStream } | null>;
-    delete(key: string): Promise<void>;
-    head(key: string): Promise<any>;
-    list(options?: { prefix?: string }): Promise<{ objects: any[] }>;
-}
+
 
 /**
  * R2 configuration for file storage and tracking
@@ -138,11 +172,12 @@ export interface R2Bucket {
  * } as const satisfies R2Config;
  * ```
  */
-export interface R2Config {
+export interface R2Config<TR2 extends R2BucketConstraint = R2BucketConstraint> {
     /**
      * R2 bucket instance
+     * Pass your R2Bucket directly - types will be inferred from your @cloudflare/workers-types.
      */
-    bucket: R2Bucket;
+    bucket: TR2;
 
     /**
      * Additional fields to track in the file metadata schema.
@@ -259,12 +294,12 @@ export interface R2Config {
 type InferFieldType<T extends FieldAttribute> = T["type"] extends "string"
     ? string
     : T["type"] extends "number"
-      ? number
-      : T["type"] extends "boolean"
-        ? boolean
-        : T["type"] extends "date"
-          ? Date
-          : any;
+    ? number
+    : T["type"] extends "boolean"
+    ? boolean
+    : T["type"] extends "date"
+    ? Date
+    : any;
 
 // Convert Record<string, FieldAttribute> to actual typed object
 type InferAdditionalFields<T extends Record<string, FieldAttribute>> = {
@@ -292,58 +327,58 @@ export type FileMetadataWithAdditionalFields<T extends Record<string, FieldAttri
     InferAdditionalFields<T>;
 
 // Infer R2Config types from runtime definition (eliminates double definition!)
-export type InferR2Config<T extends R2Config> =
+export type InferR2Config<T extends R2Config<R2BucketConstraint>> =
     T["additionalFields"] extends Record<string, FieldAttribute>
-        ? Omit<T, "hooks"> & {
-              hooks?: {
-                  upload?: {
-                      before?: (
-                          file: File & {
-                              userId: string;
-                              r2Key: string;
-                              metadata: FileMetadataWithAdditionalFields<T["additionalFields"]>;
-                          },
-                          ctx: AuthContext
-                      ) => Promise<void | null | undefined>;
+    ? Omit<T, "hooks"> & {
+        hooks?: {
+            upload?: {
+                before?: (
+                    file: File & {
+                        userId: string;
+                        r2Key: string;
+                        metadata: FileMetadataWithAdditionalFields<T["additionalFields"]>;
+                    },
+                    ctx: AuthContext
+                ) => Promise<void | null | undefined>;
 
-                      after?: (
-                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                          ctx: AuthContext
-                      ) => Promise<void>;
-                  };
+                after?: (
+                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                    ctx: AuthContext
+                ) => Promise<void>;
+            };
 
-                  download?: {
-                      before?: (
-                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                          ctx: AuthContext
-                      ) => Promise<void | null | undefined>;
+            download?: {
+                before?: (
+                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                    ctx: AuthContext
+                ) => Promise<void | null | undefined>;
 
-                      after?: (
-                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                          ctx: AuthContext
-                      ) => Promise<void>;
-                  };
+                after?: (
+                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                    ctx: AuthContext
+                ) => Promise<void>;
+            };
 
-                  delete?: {
-                      before?: (
-                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                          ctx: AuthContext
-                      ) => Promise<void | null | undefined>;
+            delete?: {
+                before?: (
+                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                    ctx: AuthContext
+                ) => Promise<void | null | undefined>;
 
-                      after?: (
-                          file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
-                          ctx: AuthContext
-                      ) => Promise<void>;
-                  };
+                after?: (
+                    file: FileMetadataWithAdditionalFields<T["additionalFields"]>,
+                    ctx: AuthContext
+                ) => Promise<void>;
+            };
 
-                  list?: {
-                      before?: (userId: string, ctx: AuthContext) => Promise<void | null | undefined>;
+            list?: {
+                before?: (userId: string, ctx: AuthContext) => Promise<void | null | undefined>;
 
-                      after?: (userId: string, files: any, ctx: AuthContext) => Promise<void>;
-                  };
-              };
-          }
-        : T;
+                after?: (userId: string, files: any, ctx: AuthContext) => Promise<void>;
+            };
+        };
+    }
+    : T;
 
 /**
  * Helper to create a fully typed R2 config with automatic type inference
@@ -384,6 +419,6 @@ export type InferR2Config<T extends R2Config> =
  * });
  * ```
  */
-export function createR2Config<T extends R2Config>(config: T): InferR2Config<T> {
+export function createR2Config<T extends R2Config<R2BucketConstraint>>(config: T): InferR2Config<T> {
     return config as InferR2Config<T>;
 }


### PR DESCRIPTION
## Problem
Type mismatch errors occur when users have a different version of `@cloudflare/workers-types` than the library expects, particularly in monorepos or projects with multiple Cloudflare dependencies.

## Solution
Introduced generic constraint interfaces (`KVNamespaceConstraint`, `R2BucketConstraint`) that define only the methods the library actually needs. Made `withCloudflare` and related types generic to accept any compatible KV/R2 types from user projects.

**Before:**
```typescript
// Hard dependency on specific @cloudflare/workers-types version
import type { KVNamespace } from "@cloudflare/workers-types";
kv?: KVNamespace<string>;
```

**After:**
```typescript
// Accepts any compatible type via generics
export interface KVNamespaceConstraint {
  get(key: string, options?: ...): Promise<string | null>;
  put(key: string, value: ..., options?: ...): Promise<void>;
  delete(key: string): Promise<void>;
}
kv?: TKV;  // Auto-inferred from user's types
```

## Result
Users can now pass platform.env bindings directly without type errors. Types are automatically inferred:

```typescript
withCloudflare({
  kv: platform.env.MY_KV  // ✅ Types inferred from your @cloudflare/workers-types
}, ...)
```