### PR TITLE
feat: add Cloudflare Email support for Better Auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bun.lock
 *.log
 .pnpm-store
 test-results/
+.opencode/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # better-auth-cloudflare
 
-Seamlessly integrate [Better Auth](https://github.com/better-auth/better-auth) with Cloudflare Workers, D1, Hyperdrive, KV, R2, and geolocation services.
+Seamlessly integrate [Better Auth](https://github.com/better-auth/better-auth) with Cloudflare Workers, D1, Hyperdrive, KV, R2, Email, and geolocation services.
 
 [![NPM Version](https://img.shields.io/npm/v/better-auth-cloudflare)](https://www.npmjs.com/package/better-auth-cloudflare)
 [![NPM Downloads](https://img.shields.io/npm/dt/better-auth-cloudflare)](https://www.npmjs.com/package/better-auth-cloudflare)
@@ -19,6 +19,7 @@ Demo implementations are available in the [`examples/`](./examples/) directory f
 - 🚀 **Hyperdrive Support**: Connect to Postgres and MySQL databases through Cloudflare Hyperdrive.
 - 🔌 **KV Storage Integration**: Optionally use Cloudflare KV for secondary storage (e.g., session caching).
 - 📁 **R2 File Storage**: Upload, download, and manage user files with Cloudflare R2 object storage and database tracking.
+- ✉️ **Cloudflare Email**: Send Better Auth verification and password reset emails through Cloudflare Email Sending.
 - 📍 **Automatic Geolocation Tracking**: Enrich user sessions with location data derived from Cloudflare.
 - 🌐 **Cloudflare IP Detection**: Utilize Cloudflare's IP detection headers out-of-the-box.
 - 🔍 **Rich Client-Side Context**: Access timezone, city, country, region, and more via the client plugin.
@@ -32,7 +33,7 @@ Demo implementations are available in the [`examples/`](./examples/) directory f
 - [x] Hyperdrive (Postgres/MySQL)
 - [x] KV
 - [x] R2
-- [ ] Cloudflare Email
+- [x] Cloudflare Email
 - [ ] Cloudflare Images
 - [ ] Durable Objects
 - [ ] D1 Multi-Tenancy
@@ -103,7 +104,7 @@ npx @better-auth-cloudflare/cli@latest migrate                         # Interac
 npx @better-auth-cloudflare/cli@latest migrate --migrate-target=prod   # Non-interactive
 ```
 
-The CLI creates projects from Hono or Next.js templates and can automatically set up D1, KV, R2, and Hyperdrive resources. See [CLI Documentation](./cli/README.md) for full documentation and all available arguments.
+The CLI creates projects from Hono or Next.js templates and can automatically set up D1, KV, R2, Hyperdrive, and Cloudflare Email bindings. See [CLI Documentation](./cli/README.md) for full documentation and all available arguments.
 
 **Troubleshooting**:
 
@@ -129,8 +130,9 @@ bun add better-auth-cloudflare
 | `geolocationTracking` | boolean | `true`      | Track geolocation data in the session table    |
 | `cf`                  | object  | `{}`        | Cloudflare geolocation context                 |
 | `r2`                  | object  | `undefined` | R2 bucket configuration for file storage       |
+| `email`               | object  | `undefined` | Cloudflare Email Sending configuration         |
 
-For the full `WithCloudflareOptions` interface (including database, KV, and Drizzle adapter options), see the [Configuration Reference](./docs/configuration.md).
+For the full `WithCloudflareOptions` interface (including database, KV, Email, and Drizzle adapter options), see the [Configuration Reference](./docs/configuration.md).
 
 ## Setup
 
@@ -216,21 +218,37 @@ function createAuth(env?: CloudflareBindings, cf?: IncomingRequestCfProperties, 
                       }
                     : undefined,
                 kv: env?.KV,
+                // Optional: Send verification and password reset emails with Cloudflare Email
+                ...(env?.EMAIL
+                    ? {
+                          email: {
+                              binding: env.EMAIL,
+                              from: env.BETTER_AUTH_EMAIL_FROM,
+                          },
+                      }
+                    : {}),
                 // Optional: Enable R2 file storage
-                r2: {
-                    bucket: env.R2_BUCKET,
-                    maxFileSize: 10 * 1024 * 1024, // 10MB
-                    allowedTypes: [".jpg", ".jpeg", ".png", ".gif", ".pdf", ".doc", ".docx"],
-                    additionalFields: {
-                        category: { type: "string", required: false },
-                        isPublic: { type: "boolean", required: false },
-                        description: { type: "string", required: false },
-                    },
-                },
+                ...(env?.R2_BUCKET
+                    ? {
+                          r2: {
+                              bucket: env.R2_BUCKET,
+                              maxFileSize: 10 * 1024 * 1024, // 10MB
+                              allowedTypes: [".jpg", ".jpeg", ".png", ".gif", ".pdf", ".doc", ".docx"],
+                              additionalFields: {
+                                  category: { type: "string", required: false },
+                                  isPublic: { type: "boolean", required: false },
+                                  description: { type: "string", required: false },
+                              },
+                          },
+                      }
+                    : {}),
             },
             {
                 emailAndPassword: {
                     enabled: true,
+                },
+                emailVerification: {
+                    sendOnSignUp: true,
                 },
                 rateLimit: {
                     enabled: true,

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ export const auth = createAuth();
 export { createAuth };
 ```
 
+> Cloudflare Email Sending requires the `from` address to use an onboarded domain. Configure the sender domain in [Cloudflare Email Service domains](https://developers.cloudflare.com/email-service/configuration/domains/) before deploying real emails.
+
 The `baseURL` is derived per-request in Hono middleware via `new URL(c.req.url).origin`. On Cloudflare Workers, `request.url` reflects the actual URL the client connected to — Cloudflare's edge routes requests to your worker based on DNS and [route configuration](https://developers.cloudflare.com/workers/configuration/routing/routes/), not the HTTP `Host` header alone. Alternatively, you can set the `BETTER_AUTH_URL` environment variable and omit the `baseURL` parameter.
 
 **For OpenNext.js with complex async requirements:**

--- a/cli/README.md
+++ b/cli/README.md
@@ -6,7 +6,7 @@
 
 > Part of the [Better Auth Cloudflare](https://github.com/zpg6/better-auth-cloudflare) ecosystem - A complete authentication solution for Cloudflare Workers with Better Auth, featuring ready-to-use templates and integrations.
 
-Generate a Better Auth Cloudflare project with D1, KV, R2, or Hyperdrive. This CLI tool provides scaffolding for both Hono and Next.js (OpenNext.js) applications with automatic Cloudflare resource setup.
+Generate a Better Auth Cloudflare project with D1, KV, R2, Hyperdrive, or Cloudflare Email. This CLI tool provides scaffolding for both Hono and Next.js (OpenNext.js) applications with automatic Cloudflare resource setup.
 
 **Note**: The `generate` command configures one primary database (D1, Postgres via Hyperdrive, or MySQL via Hyperdrive). You can add additional database connections manually after project creation.
 
@@ -23,6 +23,7 @@ Generate a Better Auth Cloudflare project with D1, KV, R2, or Hyperdrive. This C
 
 - Runs `wrangler d1/kv/r2 create` commands and configures `wrangler.toml`
 - Sets up Hyperdrive connections and auth integrations
+- Adds Cloudflare Email Sending bindings for Better Auth verification and password reset emails
 
 📦 Runs initial setup: `@better-auth/cli generate`, `drizzle-kit generate`, and optionally applies migrations
 
@@ -84,11 +85,14 @@ The migrate command automatically detects your database configuration from `wran
 --geolocation=<bool>           Enable geolocation tracking (default: true)
 --kv=<bool>                    Use KV as secondary storage for Better Auth (default: true)
 --r2=<bool>                    Enable R2 to extend Better Auth with user file storage (default: false)
+--email=<bool>                 Enable Cloudflare Email Sending integration (default: false)
 ```
 
 **KV Integration**: Provides secondary storage for Better Auth sessions, rate limiting, and other features. See [Better Auth secondary storage documentation](https://www.better-auth.com/docs/reference/options#secondarystorage).
 
 **R2 Integration**: Enables file upload and management capabilities. See [R2 setup guide](../docs/r2.md) for detailed configuration and usage.
+
+**Email Integration**: Adds a Cloudflare Email Sending binding and wires Better Auth verification and password reset callbacks. The sender address must use a domain configured in Cloudflare Email Service.
 
 ### Database-specific arguments
 
@@ -107,6 +111,8 @@ The migrate command automatically detects your database configuration from `wran
 --kv-namespace-name=<name>     KV namespace name (default: <app-name>-kv)
 --r2-binding=<binding>         R2 binding name (default: R2_BUCKET)
 --r2-bucket-name=<name>        R2 bucket name (default: <app-name>-files)
+--email-binding=<binding>      Cloudflare Email Sending binding name (default: EMAIL)
+--email-from=<address>         Default sender address (default: noreply@example.com)
 ```
 
 ### Cloudflare account arguments
@@ -142,6 +148,13 @@ Create app without KV or R2:
 
 ```bash
 npx @better-auth-cloudflare/cli generate --app-name=minimal-app --kv=false --r2=false
+```
+
+Create a Hono app with Cloudflare Email Sending:
+
+```bash
+npx @better-auth-cloudflare/cli generate --app-name=email-app --template=hono \
+  --email=true --email-from=auth@example.com
 ```
 
 Create and deploy in one command (default behavior):
@@ -184,14 +197,14 @@ npx @better-auth-cloudflare/cli migrate --migrate-target=dev
 
 ---
 
-Creates a new Better Auth Cloudflare project from Hono or OpenNext.js templates, optionally creating Cloudflare D1, KV, R2, or Hyperdrive resources for you. The migrate command runs `auth:update`, `db:generate`, and optionally `db:migrate`.
+Creates a new Better Auth Cloudflare project from Hono or OpenNext.js templates, optionally creating Cloudflare D1, KV, R2, Hyperdrive, or Email bindings for you. The migrate command runs `auth:update`, `db:generate`, and optionally `db:migrate`.
 
 ## Troubleshooting
 
 **Error `...Error [ERR_REQUIRE_ESM]: require() of ES Module...`**:
 
 Loading ECMAScript modules using `require()` should be supported by your nodejs.
-Make sure your node version is at least `v23.0.0`, `v22.12.0`, or `v20.19.0`, depending on the major version you use. 
+Make sure your node version is at least `v23.0.0`, `v22.12.0`, or `v20.19.0`, depending on the major version you use.
 Read more [here](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require)
 
 ## Related

--- a/cli/README.md
+++ b/cli/README.md
@@ -92,7 +92,7 @@ The migrate command automatically detects your database configuration from `wran
 
 **R2 Integration**: Enables file upload and management capabilities. See [R2 setup guide](../docs/r2.md) for detailed configuration and usage.
 
-**Email Integration**: Adds a Cloudflare Email Sending binding and wires Better Auth verification and password reset callbacks. The sender address must use a domain configured in Cloudflare Email Service.
+**Email Integration**: Adds a Cloudflare Email Sending binding and wires Better Auth verification and password reset callbacks. The sender address must use a domain configured in [Cloudflare Email Service](https://developers.cloudflare.com/email-service/configuration/domains/).
 
 ### Database-specific arguments
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -97,6 +97,9 @@ interface GenerateAnswers {
     r2: boolean;
     r2Binding?: string;
     r2BucketName?: string;
+    email: boolean;
+    emailBinding?: string;
+    emailFrom?: string;
     // Cloudflare account configuration
     accountId?: string;
     skipCloudflareSetup?: boolean;
@@ -695,7 +698,7 @@ function validateCliArgs(args: CliArgs): string[] {
     }
 
     // Validate binding names
-    const bindingFields = ["d1-binding", "hd-binding", "kv-binding", "r2-binding"];
+    const bindingFields = ["d1-binding", "hd-binding", "kv-binding", "r2-binding", "email-binding"];
     for (const field of bindingFields) {
         if (args[field] !== undefined && typeof args[field] === "string") {
             const error = validateBindingName(String(args[field]));
@@ -752,6 +755,9 @@ function cliArgsToAnswers(args: CliArgs): Partial<GenerateAnswers> {
     if (args.r2 !== undefined) answers.r2 = Boolean(args.r2);
     if (args["r2-binding"]) answers.r2Binding = args["r2-binding"] as string;
     if (args["r2-bucket-name"]) answers.r2BucketName = args["r2-bucket-name"] as string;
+    if (args.email !== undefined) answers.email = Boolean(args.email);
+    if (args["email-binding"]) answers.emailBinding = args["email-binding"] as string;
+    if (args["email-from"]) answers.emailFrom = args["email-from"] as string;
 
     // Cloudflare account configuration
     if (args["account-id"]) answers.accountId = args["account-id"] as string;
@@ -1007,6 +1013,7 @@ async function generate(cliArgs?: CliArgs) {
             geolocation: partialAnswers.geolocation !== undefined ? partialAnswers.geolocation : true,
             kv: partialAnswers.kv !== undefined ? partialAnswers.kv : true,
             r2: partialAnswers.r2 !== undefined ? partialAnswers.r2 : false,
+            email: partialAnswers.email !== undefined ? partialAnswers.email : false,
             // D1 defaults
             d1Name:
                 partialAnswers.d1Name ||
@@ -1028,6 +1035,9 @@ async function generate(cliArgs?: CliArgs) {
             r2BucketName:
                 partialAnswers.r2BucketName ||
                 (partialAnswers.r2 ? `${partialAnswers.appName || "my-app"}-files` : undefined),
+            // Email defaults
+            emailBinding: partialAnswers.emailBinding || (partialAnswers.email ? "EMAIL" : undefined),
+            emailFrom: partialAnswers.emailFrom || (partialAnswers.email ? "noreply@example.com" : undefined),
             // Cloudflare account configuration
             accountId: partialAnswers.accountId,
             skipCloudflareSetup:
@@ -1165,6 +1175,25 @@ async function generate(cliArgs?: CliArgs) {
                               message: "R2 bucket name",
                               placeholder: `${(results.appName as string) || "my-app"}-files`,
                               defaultValue: `${(results.appName as string) || "my-app"}-files`,
+                          }) as Promise<string>)
+                        : undefined,
+                email: () =>
+                    confirm({ message: "Enable Cloudflare Email sending?", initialValue: false }) as Promise<boolean>,
+                emailBinding: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.email
+                        ? (text({
+                              message: "Email Sending binding name",
+                              placeholder: "EMAIL",
+                              defaultValue: "EMAIL",
+                              validate: validateBindingName,
+                          }) as Promise<string>)
+                        : undefined,
+                emailFrom: ({ results }: { results: Partial<GenerateAnswers> }) =>
+                    results.email
+                        ? (text({
+                              message: "Default sender email address",
+                              placeholder: "noreply@example.com",
+                              defaultValue: "noreply@example.com",
                           }) as Promise<string>)
                         : undefined,
             },
@@ -1370,13 +1399,16 @@ export const verification = {} as any;`;
             kv: Boolean(answers.kv),
             r2: Boolean(answers.r2),
             hyperdrive: answers.database.startsWith("hyperdrive"),
+            email: Boolean(answers.email),
         },
         bindings: {
             d1: answers.d1Binding,
             kv: answers.kvBinding,
             r2: answers.r2Binding,
             hyperdrive: answers.hdBinding,
+            email: answers.emailBinding,
         },
+        emailFrom: answers.emailFrom,
         skipCloudflareSetup: answers.skipCloudflareSetup,
         resourceIds: {
             r2BucketName: answers.r2BucketName,
@@ -1413,12 +1445,14 @@ export const verification = {} as any;`;
                 kv: Boolean(answers.kv),
                 r2: Boolean(answers.r2),
                 hyperdrive: answers.database.startsWith("hyperdrive"),
+                email: Boolean(answers.email),
             },
             bindings: {
                 d1: answers.d1Binding,
                 kv: answers.kvBinding,
                 r2: answers.r2Binding,
                 hyperdrive: answers.hdBinding,
+                email: answers.emailBinding,
             },
         };
 
@@ -1470,12 +1504,14 @@ export const verification = {} as any;`;
                     kv: Boolean(answers.kv),
                     r2: Boolean(answers.r2),
                     hyperdrive: answers.database.startsWith("hyperdrive"),
+                    email: Boolean(answers.email),
                 },
                 bindings: {
                     d1: answers.d1Binding,
                     kv: answers.kvBinding,
                     r2: answers.r2Binding,
                     hyperdrive: answers.hdBinding,
+                    email: answers.emailBinding,
                 },
             };
             const envPath = join(targetDir, "src/env.d.ts");
@@ -1558,12 +1594,14 @@ export const verification = {} as any;`;
                     kv: Boolean(answers.kv),
                     r2: Boolean(answers.r2),
                     hyperdrive: answers.database.startsWith("hyperdrive"),
+                    email: Boolean(answers.email),
                 },
                 bindings: {
                     d1: answers.d1Binding,
                     kv: answers.kvBinding,
                     r2: answers.r2Binding,
                     hyperdrive: answers.hdBinding,
+                    email: answers.emailBinding,
                 },
             };
             const envPath = join(targetDir, "env.d.ts");
@@ -2273,6 +2311,7 @@ function printHelp() {
         `  --geolocation=<bool>           Enable geolocation tracking (default: true)\n` +
         `  --kv=<bool>                    Use KV as secondary storage for Better Auth (default: true)\n` +
         `  --r2=<bool>                    Enable R2 to extend Better Auth with user file storage (default: false)\n` +
+        `  --email=<bool>                 Enable Cloudflare Email Sending for auth emails (default: false)\n` +
         `  --verbose                      Show debug output during execution\n` +
         `  -v                             Show debug output (when used with other args) or version (when alone)\n` +
         `\n` +
@@ -2288,6 +2327,8 @@ function printHelp() {
         `  --kv-namespace-name=<name>     KV namespace name (default: <app-name>-kv)\n` +
         `  --r2-binding=<binding>         R2 binding name (default: R2_BUCKET)\n` +
         `  --r2-bucket-name=<name>        R2 bucket name (default: <app-name>-files)\n` +
+        `  --email-binding=<binding>      Email Sending binding name (default: EMAIL)\n` +
+        `  --email-from=<email>           Default sender address for auth emails\n` +
         `\n` +
         `Cloudflare account arguments:\n` +
         `  --account-id=<id>              Cloudflare account ID (only required if you have multiple accounts)\n` +
@@ -2308,6 +2349,9 @@ function printHelp() {
         `  # Create app without KV or R2\n` +
         `  npx @better-auth-cloudflare/cli --app-name=minimal-app --kv=false --r2=false\n` +
         `\n` +
+        `  # Create app with Cloudflare Email Sending\n` +
+        `  npx @better-auth-cloudflare/cli --app-name=email-app --email=true --email-from=auth@example.com\n` +
+        `\n` +
         `  # Skip Cloudflare setup (useful for CI/CD)\n` +
         `  npx @better-auth-cloudflare/cli --app-name=ci-app --skip-cloudflare-setup=true\n` +
         `\n` +
@@ -2327,7 +2371,7 @@ function printHelp() {
         `  npx @better-auth-cloudflare/cli migrate --migrate-target=dev\n` +
         `\n` +
         `Creates a new Better Auth Cloudflare project from Hono or OpenNext.js templates,\n` +
-        `optionally creating Cloudflare D1, KV, R2, or Hyperdrive resources for you.\n` +
+        `optionally creating Cloudflare D1, KV, R2, Email, or Hyperdrive resources for you.\n` +
         `The migrate command runs auth:update, db:generate, and optionally db:migrate.\n` +
         `\n` +
         `Cloudflare Status: https://www.cloudflarestatus.com/\n` +

--- a/cli/src/lib/auth-generator.ts
+++ b/cli/src/lib/auth-generator.ts
@@ -111,7 +111,7 @@ function generateNextjsAuth(config: AuthConfig): string {
 
     const cloudflareConfig = generateNextjsCloudflareConfig(config);
     const cliDatabaseConfig = generateCliDatabaseConfig(config);
-    const emailAuthOptions = generateEmailAuthOptions(config, true);
+    const emailAuthOptions = generateEmailAuthOptions(config);
 
     return `${imports.join("\n")}
 
@@ -359,17 +359,10 @@ function generateNextjsCloudflareConfig(config: AuthConfig): string {
     return parts.join("");
 }
 
-function generateEmailAuthOptions(config: AuthConfig, includeEmailAndPassword = false): string {
+function generateEmailAuthOptions(config: AuthConfig): string {
     if (!config.resources.email) return "";
 
-    const emailAndPassword = includeEmailAndPassword
-        ? `
-                emailAndPassword: {
-                    enabled: true,
-                },`
-        : "";
-
-    return `${emailAndPassword}
+    return `
                 emailVerification: {
                     sendOnSignUp: true,
                 },`;

--- a/cli/src/lib/auth-generator.ts
+++ b/cli/src/lib/auth-generator.ts
@@ -129,6 +129,9 @@ async function authBuilder() {
             {
                 baseURL: cfCtx.env.BETTER_AUTH_URL,
                 trustedOrigins: (cfCtx.env.BETTER_AUTH_TRUSTED_ORIGINS ?? "").split(",").filter(Boolean),
+                emailAndPassword: {
+                    enabled: true,
+                },
 ${emailAuthOptions}
                 rateLimit: {
                     enabled: true,

--- a/cli/src/lib/auth-generator.ts
+++ b/cli/src/lib/auth-generator.ts
@@ -6,12 +6,14 @@ export interface AuthConfig {
         kv: boolean;
         r2: boolean;
         hyperdrive: boolean;
+        email?: boolean;
     };
     bindings: {
         d1?: string;
         kv?: string;
         r2?: string;
         hyperdrive?: string;
+        email?: string;
     };
 }
 
@@ -46,6 +48,7 @@ function generateHonoAuth(config: AuthConfig): string {
 
     const cloudflareConfig = generateHonoCloudflareConfig(config);
     const cliDatabaseConfig = generateCliDatabaseConfig(config);
+    const emailAuthOptions = generateEmailAuthOptions(config);
 
     return `${imports.join("\n")}
 
@@ -65,7 +68,7 @@ function createAuth(env?: CloudflareBindings, cf?: IncomingRequestCfProperties, 
             {
                 emailAndPassword: {
                     enabled: true,
-                },
+                },${emailAuthOptions}
                 plugins: [anonymous()],
                 rateLimit: {
                     enabled: true,
@@ -108,6 +111,7 @@ function generateNextjsAuth(config: AuthConfig): string {
 
     const cloudflareConfig = generateNextjsCloudflareConfig(config);
     const cliDatabaseConfig = generateCliDatabaseConfig(config);
+    const emailAuthOptions = generateEmailAuthOptions(config, true);
 
     return `${imports.join("\n")}
 
@@ -125,6 +129,7 @@ async function authBuilder() {
             {
                 baseURL: cfCtx.env.BETTER_AUTH_URL,
                 trustedOrigins: (cfCtx.env.BETTER_AUTH_TRUSTED_ORIGINS ?? "").split(",").filter(Boolean),
+${emailAuthOptions}
                 rateLimit: {
                     enabled: true,
                     window: 60,
@@ -251,6 +256,18 @@ function generateHonoCloudflareConfig(config: AuthConfig): string {
                 } : {}),`);
     }
 
+    // Email configuration
+    if (config.resources.email) {
+        const binding = config.bindings.email || "EMAIL";
+        parts.push(`
+                ...(env?.${binding} ? {
+                    email: {
+                        binding: env.${binding},
+                        from: env.BETTER_AUTH_EMAIL_FROM,
+                    },
+                } : {}),`);
+    }
+
     return parts.join("");
 }
 
@@ -327,7 +344,35 @@ function generateNextjsCloudflareConfig(config: AuthConfig): string {
                 },`);
     }
 
+    // Email configuration
+    if (config.resources.email) {
+        const binding = config.bindings.email || "EMAIL";
+        parts.push(`
+                ...(cfCtx.env.${binding} ? {
+                    email: {
+                        binding: cfCtx.env.${binding},
+                        from: cfCtx.env.BETTER_AUTH_EMAIL_FROM,
+                    },
+                } : {}),`);
+    }
+
     return parts.join("");
+}
+
+function generateEmailAuthOptions(config: AuthConfig, includeEmailAndPassword = false): string {
+    if (!config.resources.email) return "";
+
+    const emailAndPassword = includeEmailAndPassword
+        ? `
+                emailAndPassword: {
+                    enabled: true,
+                },`
+        : "";
+
+    return `${emailAndPassword}
+                emailVerification: {
+                    sendOnSignUp: true,
+                },`;
 }
 
 function generateSchemaConfig(config: AuthConfig): string {

--- a/cli/src/lib/env-d-generator.ts
+++ b/cli/src/lib/env-d-generator.ts
@@ -10,12 +10,14 @@ export interface EnvDConfig {
         kv: boolean;
         r2: boolean;
         hyperdrive: boolean;
+        email?: boolean;
     };
     bindings: {
         d1?: string;
         kv?: string;
         r2?: string;
         hyperdrive?: string;
+        email?: string;
     };
     database: "sqlite" | "postgres" | "mysql";
 }
@@ -48,6 +50,16 @@ export function generateEnvDFile(config: EnvDConfig): string {
     if (config.resources.r2 && config.bindings.r2) {
         typeImports.push("R2Bucket");
         bindings.push(`    ${config.bindings.r2}: R2Bucket;`);
+    }
+
+    // Add Email Sending binding
+    if (config.resources.email && config.bindings.email) {
+        typeImports.push("SendEmail");
+        bindings.push(`    ${config.bindings.email}: SendEmail;`);
+    }
+
+    if (config.resources.email) {
+        bindings.push("    BETTER_AUTH_EMAIL_FROM: string;");
     }
 
     // Always include at least one binding to prevent empty interface
@@ -126,6 +138,7 @@ export function validateEnvDContent(
                     line.includes(": KVNamespace") ||
                     line.includes(": R2Bucket") ||
                     line.includes(": Hyperdrive") ||
+                    line.includes(": SendEmail") ||
                     line.includes(": string")
                 ) {
                     errors.push(`Line ${i + 1} should end with semicolon: ${line}`);

--- a/cli/src/lib/typescript-validator.ts
+++ b/cli/src/lib/typescript-validator.ts
@@ -69,10 +69,23 @@ export class TypeScriptValidator {
 
             // No need for package.json - if imports fail, that's a validation error we want to catch
 
-            // Try to use TypeScript compiler - use local installation from CLI project
-            // Run from CLI project directory but specify the temp directory's tsconfig
+            // Try to use TypeScript compiler - prefer the local CLI dependency first.
+            // Run from CLI project directory but specify the temp directory's tsconfig.
             const cliProjectDir = join(__dirname, "..", "..");
-            let result = spawnSync("npx", ["tsc", "--project", this.tempDir, "--noEmit"], {
+            const localTsc = join(
+                cliProjectDir,
+                "node_modules",
+                ".bin",
+                process.platform === "win32" ? "tsc.cmd" : "tsc"
+            );
+            const localTscPackage = join(cliProjectDir, "node_modules", "typescript", "bin", "tsc");
+            const command = existsSync(localTsc) ? localTsc : existsSync(localTscPackage) ? "node" : "npx";
+            const args = existsSync(localTsc)
+                ? ["--project", this.tempDir, "--noEmit"]
+                : existsSync(localTscPackage)
+                  ? [localTscPackage, "--project", this.tempDir, "--noEmit"]
+                  : ["tsc", "--project", this.tempDir, "--noEmit"];
+            let result = spawnSync(command, args, {
                 cwd: cliProjectDir,
                 encoding: "utf8",
                 stdio: "pipe",

--- a/cli/src/lib/wrangler-generator.ts
+++ b/cli/src/lib/wrangler-generator.ts
@@ -146,7 +146,7 @@ localConnectionString = "${localConnectionString}"`);
 name = "${binding}"
 
 [vars]
-BETTER_AUTH_EMAIL_FROM = "${config.emailFrom || "noreply@example.com"}"`);
+BETTER_AUTH_EMAIL_FROM = "${(config.emailFrom || "noreply@example.com").replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\r?\n/g, "\\n")}"`);
     }
 
     return resources.join("\n");

--- a/cli/src/lib/wrangler-generator.ts
+++ b/cli/src/lib/wrangler-generator.ts
@@ -6,13 +6,16 @@ export interface WranglerConfig {
         kv: boolean;
         r2: boolean;
         hyperdrive: boolean;
+        email?: boolean;
     };
     bindings: {
         d1?: string;
         kv?: string;
         r2?: string;
         hyperdrive?: string;
+        email?: string;
     };
+    emailFrom?: string;
     skipCloudflareSetup?: boolean;
     resourceIds?: {
         d1?: string;
@@ -132,6 +135,18 @@ bucket_name = "${bucketName}"`);
 binding = "${binding}"
 id = "${hyperdriveId}"
 localConnectionString = "${localConnectionString}"`);
+    }
+
+    // Email Sending
+    if (config.resources.email) {
+        const binding = config.bindings.email || "EMAIL";
+
+        resources.push(`
+[[send_email]]
+name = "${binding}"
+
+[vars]
+BETTER_AUTH_EMAIL_FROM = "${config.emailFrom || "noreply@example.com"}"`);
     }
 
     return resources.join("\n");

--- a/cli/tests/auth-generator.test.ts
+++ b/cli/tests/auth-generator.test.ts
@@ -86,6 +86,24 @@ describe("Auth Generator", () => {
             expect(result).toContain("hooks: {");
         });
 
+        test("generates Email configuration with custom binding", () => {
+            const config: AuthConfig = {
+                template: "hono",
+                database: "sqlite",
+                resources: { d1: true, kv: false, r2: false, hyperdrive: false, email: true },
+                bindings: { d1: "DATABASE", email: "AUTH_EMAIL" },
+            };
+
+            const result = generateAuthFile(config);
+
+            expect(result).toContain("...(env?.AUTH_EMAIL ? {");
+            expect(result).toContain("email: {");
+            expect(result).toContain("binding: env.AUTH_EMAIL");
+            expect(result).toContain("from: env.BETTER_AUTH_EMAIL_FROM");
+            expect(result).toContain("emailVerification: {");
+            expect(result).toContain("sendOnSignUp: true");
+        });
+
         test("generates all resources configuration", () => {
             const config: AuthConfig = {
                 template: "hono",
@@ -184,6 +202,26 @@ describe("Auth Generator", () => {
             expect(result).toContain("r2: {");
             expect(result).toContain("bucket: {} as any, // Mock bucket for schema generation");
             expect(result).toContain("additionalFields: {");
+        });
+
+        test("generates Email configuration only for runtime", () => {
+            const config: AuthConfig = {
+                template: "nextjs",
+                database: "sqlite",
+                resources: { d1: true, kv: false, r2: false, hyperdrive: false, email: true },
+                bindings: { d1: "DATABASE", email: "AUTH_EMAIL" },
+            };
+
+            const result = generateAuthFile(config);
+
+            expect(result).toContain("...(cfCtx.env.AUTH_EMAIL ? {");
+            expect(result).toContain("binding: cfCtx.env.AUTH_EMAIL");
+            expect(result).toContain("from: cfCtx.env.BETTER_AUTH_EMAIL_FROM");
+            expect(result).toContain("emailAndPassword: {");
+            expect(result).toContain("enabled: true");
+            expect(result).toContain("emailVerification: {");
+            expect(result).toContain("sendOnSignUp: true");
+            expect(result).not.toContain("AUTH_EMAIL: {} as any");
         });
     });
 

--- a/cli/tests/auth-generator.test.ts
+++ b/cli/tests/auth-generator.test.ts
@@ -217,8 +217,6 @@ describe("Auth Generator", () => {
             expect(result).toContain("...(cfCtx.env.AUTH_EMAIL ? {");
             expect(result).toContain("binding: cfCtx.env.AUTH_EMAIL");
             expect(result).toContain("from: cfCtx.env.BETTER_AUTH_EMAIL_FROM");
-            expect(result).toContain("emailAndPassword: {");
-            expect(result).toContain("enabled: true");
             expect(result).toContain("emailVerification: {");
             expect(result).toContain("sendOnSignUp: true");
             expect(result).not.toContain("AUTH_EMAIL: {} as any");

--- a/cli/tests/email-helper.test.ts
+++ b/cli/tests/email-helper.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import { createEmailOptions, createEmailSender } from "../../src/email";
+import type { EmailAddress, EmailMessage, EmailSendResult, SendEmail } from "@cloudflare/workers-types";
+import type { CloudflareEmailMessage } from "../../src/types";
+
+type StructuredEmailMessage = {
+    from: string | EmailAddress;
+    to: string | string[];
+    subject: string;
+    replyTo?: string | EmailAddress;
+    cc?: string | string[];
+    bcc?: string | string[];
+    headers?: Record<string, string>;
+    text?: string;
+    html?: string;
+};
+
+class RecordingEmailBinding implements SendEmail {
+    readonly sent: StructuredEmailMessage[] = [];
+
+    async send(message: EmailMessage): Promise<EmailSendResult>;
+    async send(builder: StructuredEmailMessage): Promise<EmailSendResult>;
+    async send(message: EmailMessage | StructuredEmailMessage): Promise<EmailSendResult> {
+        if ("subject" in message) {
+            this.sent.push(message);
+        } else {
+            this.sent.push({
+                from: message.from,
+                to: message.to,
+                subject: "",
+            });
+        }
+
+        return { messageId: `message-${this.sent.length}` };
+    }
+}
+
+const user = {
+    id: "user_1",
+    email: "user@example.com",
+    name: "User",
+    image: null,
+    emailVerified: false,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+describe("createEmailSender", () => {
+    test("sends structured email through the Cloudflare binding", async () => {
+        const binding = new RecordingEmailBinding();
+        const sendEmail = createEmailSender({
+            binding,
+            from: { email: "auth@example.com", name: "Auth" },
+            replyTo: "support@example.com",
+        });
+
+        const result = await sendEmail({
+            to: "user@example.com",
+            subject: "Verify your email",
+            text: "Open the verification link.",
+            html: "<p>Open the verification link.</p>",
+            headers: { "X-Auth-Flow": "verification" },
+        });
+
+        expect(result).toEqual({ messageId: "message-1" });
+        expect(binding.sent).toEqual([
+            {
+                from: { email: "auth@example.com", name: "Auth" },
+                to: "user@example.com",
+                subject: "Verify your email",
+                replyTo: "support@example.com",
+                text: "Open the verification link.",
+                html: "<p>Open the verification link.</p>",
+                headers: { "X-Auth-Flow": "verification" },
+            },
+        ]);
+    });
+
+    test("requires text or html content", async () => {
+        const binding = new RecordingEmailBinding();
+        const sendEmail = createEmailSender({ binding, from: "auth@example.com" });
+
+        await expect(
+            sendEmail({
+                to: "user@example.com",
+                subject: "Missing body",
+            })
+        ).rejects.toThrow("Cloudflare Email requires at least one of `text` or `html` content.");
+        expect(binding.sent).toEqual([]);
+    });
+});
+
+describe("createEmailOptions", () => {
+    test("adds default verification and reset callbacks when Email is configured", async () => {
+        const binding = new RecordingEmailBinding();
+        const options = createEmailOptions(
+            {
+                binding,
+                from: "auth@example.com",
+            },
+            {}
+        );
+
+        await options.emailVerification?.sendVerificationEmail?.({
+            user,
+            url: "https://app.example.com/verify?token=abc&next=<home>",
+            token: "abc",
+        });
+        await options.emailAndPassword?.sendResetPassword?.({
+            user,
+            url: "https://app.example.com/reset?token=def",
+            token: "def",
+        });
+
+        expect(options.emailAndPassword?.enabled).toBe(true);
+        expect(binding.sent).toHaveLength(2);
+        expect(binding.sent[0]).toMatchObject({
+            from: "auth@example.com",
+            to: "user@example.com",
+            subject: "Verify your email address",
+        });
+        expect(binding.sent[0]?.text).toContain("https://app.example.com/verify?token=abc&next=<home>");
+        expect(binding.sent[0]?.html).toContain("next=&lt;home&gt;");
+        expect(binding.sent[1]).toMatchObject({
+            from: "auth@example.com",
+            to: "user@example.com",
+            subject: "Reset your password",
+        });
+    });
+
+    test("preserves user callbacks and disabled email/password auth", async () => {
+        const binding = new RecordingEmailBinding();
+        const customMessage: CloudflareEmailMessage = {
+            to: "owner@example.com",
+            subject: "Custom",
+            text: "Custom callback",
+        };
+        const options = createEmailOptions(
+            {
+                binding,
+                from: "auth@example.com",
+            },
+            {
+                emailVerification: {
+                    sendVerificationEmail: async () => {
+                        await createEmailSender({ binding, from: "custom@example.com" })(customMessage);
+                    },
+                },
+                emailAndPassword: {
+                    enabled: false,
+                },
+            }
+        );
+
+        await options.emailVerification?.sendVerificationEmail?.({
+            user,
+            url: "https://app.example.com/verify",
+            token: "abc",
+        });
+
+        expect(options.emailAndPassword?.enabled).toBe(false);
+        expect(binding.sent).toEqual([
+            {
+                from: "custom@example.com",
+                to: "owner@example.com",
+                subject: "Custom",
+                text: "Custom callback",
+            },
+        ]);
+    });
+});

--- a/cli/tests/email-helper.test.ts
+++ b/cli/tests/email-helper.test.ts
@@ -91,7 +91,7 @@ describe("createEmailSender", () => {
 });
 
 describe("createEmailOptions", () => {
-    test("adds default verification and reset callbacks when Email is configured", async () => {
+    test("adds a default verification callback without enabling password auth", async () => {
         const binding = new RecordingEmailBinding();
         const options = createEmailOptions(
             {
@@ -106,14 +106,9 @@ describe("createEmailOptions", () => {
             url: "https://app.example.com/verify?token=abc&next=<home>",
             token: "abc",
         });
-        await options.emailAndPassword?.sendResetPassword?.({
-            user,
-            url: "https://app.example.com/reset?token=def",
-            token: "def",
-        });
 
-        expect(options.emailAndPassword?.enabled).toBe(true);
-        expect(binding.sent).toHaveLength(2);
+        expect(options.emailAndPassword).toBeUndefined();
+        expect(binding.sent).toHaveLength(1);
         expect(binding.sent[0]).toMatchObject({
             from: "auth@example.com",
             to: "user@example.com",
@@ -121,11 +116,37 @@ describe("createEmailOptions", () => {
         });
         expect(binding.sent[0]?.text).toContain("https://app.example.com/verify?token=abc&next=<home>");
         expect(binding.sent[0]?.html).toContain("next=&lt;home&gt;");
-        expect(binding.sent[1]).toMatchObject({
+    });
+
+    test("adds a reset callback when email/password auth is already configured", async () => {
+        const binding = new RecordingEmailBinding();
+        const options = createEmailOptions(
+            {
+                binding,
+                from: "auth@example.com",
+            },
+            {
+                emailAndPassword: {
+                    enabled: true,
+                },
+            }
+        );
+
+        await options.emailAndPassword?.sendResetPassword?.({
+            user,
+            url: "https://app.example.com/reset?token=def",
+            token: "def",
+        });
+
+        expect(options.emailAndPassword?.enabled).toBe(true);
+        expect(binding.sent).toHaveLength(1);
+        expect(binding.sent[0]).toMatchObject({
             from: "auth@example.com",
             to: "user@example.com",
             subject: "Reset your password",
         });
+        expect(binding.sent[0]?.text).toContain("Reset your password by opening this link");
+        expect(binding.sent[0]?.html).toContain("Reset your password by opening this link");
     });
 
     test("preserves user callbacks and disabled email/password auth", async () => {

--- a/cli/tests/env-d-generator.test.ts
+++ b/cli/tests/env-d-generator.test.ts
@@ -147,6 +147,52 @@ describe("env.d.ts Generator", () => {
         expect(result).not.toContain("R2Bucket");
     });
 
+    test("generates env.d.ts with Email Sending", () => {
+        const config: EnvDConfig = {
+            template: "hono",
+            database: "sqlite",
+            resources: {
+                d1: false,
+                kv: false,
+                r2: false,
+                hyperdrive: false,
+                email: true,
+            },
+            bindings: {
+                email: "AUTH_EMAIL",
+            },
+        };
+
+        const result = generateEnvDFile(config);
+
+        expect(result).toContain('import type { SendEmail } from "@cloudflare/workers-types"');
+        expect(result).toContain("AUTH_EMAIL: SendEmail;");
+        expect(result).toContain("BETTER_AUTH_EMAIL_FROM: string;");
+    });
+
+    test("generates Next.js env.d.ts with Email Sending", () => {
+        const config: EnvDConfig = {
+            template: "nextjs",
+            database: "sqlite",
+            resources: {
+                d1: false,
+                kv: false,
+                r2: false,
+                hyperdrive: false,
+                email: true,
+            },
+            bindings: {
+                email: "EMAIL",
+            },
+        };
+
+        const result = generateEnvDFile(config);
+
+        expect(result).toContain("interface CloudflareEnv");
+        expect(result).toContain("EMAIL: SendEmail;");
+        expect(result).toContain("BETTER_AUTH_EMAIL_FROM: string;");
+    });
+
     test("generates env.d.ts with custom Hyperdrive binding name", () => {
         const config: EnvDConfig = {
             template: "hono",

--- a/cli/tests/non-interactive-args.test.ts
+++ b/cli/tests/non-interactive-args.test.ts
@@ -82,7 +82,7 @@ function validateCliArgs(args: CliArgs): string[] {
     }
 
     // Validate binding names
-    const bindingFields = ["d1-binding", "hd-binding", "kv-binding", "r2-binding"];
+    const bindingFields = ["d1-binding", "hd-binding", "kv-binding", "r2-binding", "email-binding"];
     for (const field of bindingFields) {
         if (args[field] !== undefined && typeof args[field] === "string") {
             const error = validateBindingName(String(args[field]));
@@ -128,12 +128,13 @@ describe("CLI Argument Parsing", () => {
     });
 
     test("parses boolean values correctly", () => {
-        const argv = ["node", "cli", "--geolocation=true", "--kv=false", "--r2"];
+        const argv = ["node", "cli", "--geolocation=true", "--kv=false", "--r2", "--email=true"];
         const args = parseCliArgs(argv);
 
         expect(args.geolocation).toBe(true);
         expect(args.kv).toBe(false);
         expect(args.r2).toBe(true); // flag defaults to true
+        expect(args.email).toBe(true);
     });
 
     test("handles values with equals signs", () => {
@@ -204,7 +205,7 @@ describe("CLI Argument Validation", () => {
     });
 
     test("validates binding names", () => {
-        const validArgs = { "d1-binding": "MY_DATABASE_123" };
+        const validArgs = { "d1-binding": "MY_DATABASE_123", "email-binding": "AUTH_EMAIL" };
         const invalidArgs1 = { "kv-binding": "my-binding" }; // lowercase
         const invalidArgs2 = { "r2-binding": "MY-BINDING-WITH-HYPHENS" }; // hyphens
         const invalidArgs3 = { "hd-binding": "" }; // empty
@@ -318,6 +319,9 @@ describe("Real-world CLI Usage Scenarios", () => {
             "--r2=true",
             "--r2-binding=FILE_STORAGE",
             "--r2-bucket-name=app-uploads",
+            "--email=true",
+            "--email-binding=AUTH_EMAIL",
+            "--email-from=auth@example.com",
         ];
         const args = parseCliArgs(argv);
         const errors = validateCliArgs(args);
@@ -336,6 +340,9 @@ describe("Real-world CLI Usage Scenarios", () => {
         expect(args.r2).toBe(true);
         expect(args["r2-binding"]).toBe("FILE_STORAGE");
         expect(args["r2-bucket-name"]).toBe("app-uploads");
+        expect(args.email).toBe(true);
+        expect(args["email-binding"]).toBe("AUTH_EMAIL");
+        expect(args["email-from"]).toBe("auth@example.com");
     });
 });
 

--- a/cli/tests/wrangler-generator.test.ts
+++ b/cli/tests/wrangler-generator.test.ts
@@ -191,17 +191,52 @@ describe("Wrangler Generator", () => {
         });
     });
 
+    describe("Email Sending Configuration", () => {
+        test("generates Email Sending configuration with default binding", () => {
+            const config: WranglerConfig = {
+                appName: "test-app",
+                template: "hono",
+                resources: { d1: false, kv: false, r2: false, hyperdrive: false, email: true },
+                bindings: {},
+            };
+
+            const result = generateWranglerToml(config);
+
+            expect(result).toContain("[[send_email]]");
+            expect(result).toContain('name = "EMAIL"');
+            expect(result).toContain("[vars]");
+            expect(result).toContain('BETTER_AUTH_EMAIL_FROM = "noreply@example.com"');
+        });
+
+        test("generates Email Sending configuration with custom binding and sender", () => {
+            const config: WranglerConfig = {
+                appName: "test-app",
+                template: "hono",
+                resources: { d1: false, kv: false, r2: false, hyperdrive: false, email: true },
+                bindings: { email: "AUTH_EMAIL" },
+                emailFrom: "auth@example.com",
+            };
+
+            const result = generateWranglerToml(config);
+
+            expect(result).toContain("[[send_email]]");
+            expect(result).toContain('name = "AUTH_EMAIL"');
+            expect(result).toContain('BETTER_AUTH_EMAIL_FROM = "auth@example.com"');
+        });
+    });
+
     describe("Multiple Resources", () => {
         test("generates all resources configuration", () => {
             const config: WranglerConfig = {
                 appName: "test-app",
                 template: "nextjs",
-                resources: { d1: true, kv: true, r2: true, hyperdrive: true },
+                resources: { d1: true, kv: true, r2: true, hyperdrive: true, email: true },
                 bindings: {
                     d1: "DATABASE",
                     kv: "KV",
                     r2: "R2_BUCKET",
                     hyperdrive: "HYPERDRIVE",
+                    email: "EMAIL",
                 },
             };
 
@@ -211,6 +246,8 @@ describe("Wrangler Generator", () => {
             expect(result).toContain("[[kv_namespaces]]");
             expect(result).toContain("[[r2_buckets]]");
             expect(result).toContain("[[hyperdrive]]");
+            expect(result).toContain("[[send_email]]");
+            expect(result).toContain('name = "EMAIL"');
             expect(result).toContain("[assets]"); // Next.js specific
         });
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,13 +26,15 @@ const auth = betterAuth({
 
 `withCloudflare` returns a merged config object. The following keys are **always set** by the wrapper and take precedence over values in `authOptions`:
 
-| Key                | Behavior                                                                                                                                                    |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `database`         | Set from your `d1` / `d1Native` / `postgres` / `mysql` option. Omit `database` from `authOptions`.                                                          |
-| `secondaryStorage` | Set to `createKVStorage(kv)` when `kv` is provided, otherwise `undefined`. Omit from `authOptions`.                                                         |
-| `plugins`          | The `cloudflare()` plugin is prepended to your `authOptions.plugins` array.                                                                                 |
-| `advanced`         | Merges your `authOptions.advanced` with IP detection headers when `autoDetectIpAddress` is enabled.                                                         |
-| `session`          | Merges your `authOptions.session`, forcing `storeSessionInDatabase: true` when `geolocationTracking` is enabled — even if you explicitly set it to `false`. |
+| Key                 | Behavior                                                                                                                                                    |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `database`          | Set from your `d1` / `d1Native` / `postgres` / `mysql` option. Omit `database` from `authOptions`.                                                          |
+| `secondaryStorage`  | Set to `createKVStorage(kv)` when `kv` is provided, otherwise `undefined`. Omit from `authOptions`.                                                         |
+| `plugins`           | The `cloudflare()` plugin is prepended to your `authOptions.plugins` array.                                                                                 |
+| `advanced`          | Merges your `authOptions.advanced` with IP detection headers when `autoDetectIpAddress` is enabled.                                                         |
+| `session`           | Merges your `authOptions.session`, forcing `storeSessionInDatabase: true` when `geolocationTracking` is enabled — even if you explicitly set it to `false`. |
+| `emailVerification` | Adds a Cloudflare Email `sendVerificationEmail` callback when `email` is configured and no custom callback exists.                                          |
+| `emailAndPassword`  | Adds a Cloudflare Email `sendResetPassword` callback when `email` is configured and no custom callback exists.                                              |
 
 If you need a custom `secondaryStorage` that is not KV, omit the `kv` option and set `secondaryStorage` outside the spread:
 
@@ -47,7 +49,7 @@ const auth = betterAuth({
 
 ## `WithCloudflareOptions`
 
-Extends [`CloudflarePluginOptions`](#cloudflarepluginoptions) with database and KV configuration.
+Extends [`CloudflarePluginOptions`](#cloudflarepluginoptions) with database, KV, and Email configuration.
 
 ### Database Options
 
@@ -65,6 +67,12 @@ Only **one** database option may be provided — passing more than one throws at
 | Option | Type          | Description                                                                                                                   |
 | ------ | ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | `kv`   | `KVNamespace` | KV namespace for [secondary storage](#kv-secondary-storage). Automatically wired as `secondaryStorage` via `createKVStorage`. |
+
+### Email Option
+
+| Option  | Type                    | Description                                                                                              |
+| ------- | ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| `email` | `CloudflareEmailConfig` | Cloudflare Email Sending binding and defaults for Better Auth verification and password reset callbacks. |
 
 ### `DrizzleConfig<T>`
 
@@ -172,6 +180,66 @@ rateLimit: {
 
 ---
 
+## Cloudflare Email Sending
+
+Passing `email` to `withCloudflare` enables default Better Auth transactional email callbacks backed by Cloudflare Email Sending.
+
+```typescript
+withCloudflare(
+    {
+        d1: { db, options: { usePlural: true } },
+        kv: env.KV,
+        cf: request.cf,
+        email: {
+            binding: env.EMAIL,
+            from: env.BETTER_AUTH_EMAIL_FROM,
+        },
+    },
+    {
+        emailAndPassword: { enabled: true },
+        emailVerification: { sendOnSignUp: true },
+    }
+);
+```
+
+`withCloudflare` only fills missing callbacks. If `authOptions.emailVerification.sendVerificationEmail` or `authOptions.emailAndPassword.sendResetPassword` already exists, your callback is preserved.
+
+### `CloudflareEmailConfig`
+
+| Field                     | Type                      | Default     | Description                                                                       |
+| ------------------------- | ------------------------- | ----------- | --------------------------------------------------------------------------------- |
+| `binding`                 | `SendEmail`               | Required    | Cloudflare Email Sending binding from `wrangler.toml`.                            |
+| `from`                    | `string \| EmailAddress`  | Required    | Default sender address. The domain must be onboarded in Cloudflare Email Service. |
+| `replyTo`                 | `string \| EmailAddress`  | `undefined` | Optional default Reply-To address.                                                |
+| `sendVerificationEmail`   | `boolean`                 | `true`      | Set to `false` to avoid auto-wiring Better Auth email verification.               |
+| `sendResetPassword`       | `boolean`                 | `true`      | Set to `false` to avoid auto-wiring Better Auth password reset emails.            |
+| `templates.verification`  | `CloudflareEmailTemplate` | Built-in    | Optional custom verification email subject/body template.                         |
+| `templates.passwordReset` | `CloudflareEmailTemplate` | Built-in    | Optional custom password reset subject/body template.                             |
+
+### `createEmailSender(config)`
+
+Creates a reusable sender around the Cloudflare binding:
+
+```typescript
+import { createEmailSender } from "better-auth-cloudflare";
+
+const sendEmail = createEmailSender({
+    binding: env.EMAIL,
+    from: "auth@example.com",
+});
+
+await sendEmail({
+    to: "user@example.com",
+    subject: "Welcome",
+    text: "Welcome to the app.",
+    html: "<p>Welcome to the app.</p>",
+});
+```
+
+At least one of `text` or `html` is required. Cloudflare Email Service requires the `from` domain to be configured for Email Sending.
+
+---
+
 ## Database Examples
 
 ### D1 with Drizzle
@@ -273,6 +341,10 @@ id = "<your-kv-namespace-id>"
 binding = "R2_BUCKET"
 bucket_name = "my-files"
 
+# Email Sending (optional) — Configure the domain in Cloudflare Email Service first
+[[send_email]]
+name = "EMAIL"
+
 # Hyperdrive (optional) — Create with: wrangler hyperdrive create my-hd --connection-string="..."
 # [[hyperdrive]]
 # binding = "HYPERDRIVE"
@@ -280,6 +352,7 @@ bucket_name = "my-files"
 
 [vars]
 BETTER_AUTH_URL = "https://your-app.example.com"
+BETTER_AUTH_EMAIL_FROM = "auth@example.com"
 BETTER_AUTH_TRUSTED_ORIGINS = "https://your-app.example.com"
 ```
 
@@ -288,19 +361,21 @@ BETTER_AUTH_TRUSTED_ORIGINS = "https://your-app.example.com"
 The `binding` value in `wrangler.toml` determines the property name on `env`. Declare them for type safety:
 
 ```typescript
-import type { D1Database, Hyperdrive, KVNamespace, R2Bucket } from "@cloudflare/workers-types";
+import type { D1Database, Hyperdrive, KVNamespace, R2Bucket, SendEmail } from "@cloudflare/workers-types";
 
 interface CloudflareBindings {
     DATABASE: D1Database;
     KV: KVNamespace;
     R2_BUCKET: R2Bucket;
+    EMAIL: SendEmail;
     HYPERDRIVE: Hyperdrive; // Only if using Hyperdrive
     BETTER_AUTH_URL: string;
+    BETTER_AUTH_EMAIL_FROM: string;
     BETTER_AUTH_TRUSTED_ORIGINS: string;
 }
 ```
 
-These names are configurable — if you change `binding = "KV"` to `binding = "AUTH_KV"` in `wrangler.toml`, update `env.d.ts` and your auth config to match. The [CLI](../cli/README.md) supports `--kv-binding`, `--d1-binding`, and `--r2-binding` flags for this.
+These names are configurable — if you change `binding = "KV"` to `binding = "AUTH_KV"` in `wrangler.toml`, update `env.d.ts` and your auth config to match. The [CLI](../cli/README.md) supports `--kv-binding`, `--d1-binding`, `--r2-binding`, and `--email-binding` flags for this.
 
 ---
 
@@ -313,11 +388,13 @@ The main entry point (`better-auth-cloudflare`) re-exports all types and functio
 | `withCloudflare`            | function | Wraps `BetterAuthOptions` with Cloudflare integrations (database, KV, plugin).   |
 | `cloudflare`                | function | Standalone Better Auth plugin for geolocation, IP detection, and R2.             |
 | `createKVStorage`           | function | Creates a `SecondaryStorage` backed by Cloudflare KV.                            |
+| `createEmailSender`         | function | Creates a transactional email sender backed by Cloudflare Email Sending.         |
 | `createR2Config`            | function | Helper for creating a fully type-inferred `R2Config`.                            |
 | `CloudflareGeolocation`     | type     | The 8 geolocation fields extracted from `request.cf`.                            |
 | `CloudflareSession`         | type     | `Session` extended with geolocation fields.                                      |
 | `CloudflareSessionResponse` | type     | `{ session: CloudflareSession; user: User }` — shape of `/api/auth/get-session`. |
 | `CloudflarePluginOptions`   | type     | Options for the standalone `cloudflare()` plugin.                                |
 | `WithCloudflareOptions`     | type     | Options for the `withCloudflare` wrapper.                                        |
+| `CloudflareEmailConfig`     | type     | Cloudflare Email Sending binding, sender defaults, and Better Auth templates.    |
 | `R2Config`                  | type     | R2 bucket configuration. See the [R2 File Storage Guide](./r2.md).               |
 | `FileMetadata`              | type     | Core file record shape stored in the database.                                   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,7 +34,7 @@ const auth = betterAuth({
 | `advanced`          | Merges your `authOptions.advanced` with IP detection headers when `autoDetectIpAddress` is enabled.                                                         |
 | `session`           | Merges your `authOptions.session`, forcing `storeSessionInDatabase: true` when `geolocationTracking` is enabled — even if you explicitly set it to `false`. |
 | `emailVerification` | Adds a Cloudflare Email `sendVerificationEmail` callback when `email` is configured and no custom callback exists.                                          |
-| `emailAndPassword`  | Adds a Cloudflare Email `sendResetPassword` callback when `email` is configured and no custom callback exists.                                              |
+| `emailAndPassword`  | Adds a Cloudflare Email `sendResetPassword` callback when `email` is configured and `emailAndPassword` is enabled and no custom callback exists.            |
 
 If you need a custom `secondaryStorage` that is not KV, omit the `kv` option and set `secondaryStorage` outside the spread:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,15 +206,15 @@ withCloudflare(
 
 ### `CloudflareEmailConfig`
 
-| Field                     | Type                      | Default     | Description                                                                       |
-| ------------------------- | ------------------------- | ----------- | --------------------------------------------------------------------------------- |
-| `binding`                 | `SendEmail`               | Required    | Cloudflare Email Sending binding from `wrangler.toml`.                            |
-| `from`                    | `string \| EmailAddress`  | Required    | Default sender address. The domain must be onboarded in Cloudflare Email Service. |
-| `replyTo`                 | `string \| EmailAddress`  | `undefined` | Optional default Reply-To address.                                                |
-| `sendVerificationEmail`   | `boolean`                 | `true`      | Set to `false` to avoid auto-wiring Better Auth email verification.               |
-| `sendResetPassword`       | `boolean`                 | `true`      | Set to `false` to avoid auto-wiring Better Auth password reset emails.            |
-| `templates.verification`  | `CloudflareEmailTemplate` | Built-in    | Optional custom verification email subject/body template.                         |
-| `templates.passwordReset` | `CloudflareEmailTemplate` | Built-in    | Optional custom password reset subject/body template.                             |
+| Field                     | Type                      | Default     | Description                                                                                                                                                 |
+| ------------------------- | ------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `binding`                 | `SendEmail`               | Required    | Cloudflare Email Sending binding from `wrangler.toml`.                                                                                                      |
+| `from`                    | `string \| EmailAddress`  | Required    | Default sender address. The domain must be onboarded in [Cloudflare Email Service](https://developers.cloudflare.com/email-service/configuration/domains/). |
+| `replyTo`                 | `string \| EmailAddress`  | `undefined` | Optional default Reply-To address.                                                                                                                          |
+| `sendVerificationEmail`   | `boolean`                 | `true`      | Set to `false` to avoid auto-wiring Better Auth email verification.                                                                                         |
+| `sendResetPassword`       | `boolean`                 | `true`      | Set to `false` to avoid auto-wiring Better Auth password reset emails.                                                                                      |
+| `templates.verification`  | `CloudflareEmailTemplate` | Built-in    | Optional custom verification email subject/body template.                                                                                                   |
+| `templates.passwordReset` | `CloudflareEmailTemplate` | Built-in    | Optional custom password reset subject/body template.                                                                                                       |
 
 ### `createEmailSender(config)`
 
@@ -236,7 +236,7 @@ await sendEmail({
 });
 ```
 
-At least one of `text` or `html` is required. Cloudflare Email Service requires the `from` domain to be configured for Email Sending.
+At least one of `text` or `html` is required. Cloudflare Email Service requires the `from` domain to be [configured for Email Sending](https://developers.cloudflare.com/email-service/configuration/domains/).
 
 ---
 

--- a/examples/hono/src/auth/index.ts
+++ b/examples/hono/src/auth/index.ts
@@ -28,10 +28,21 @@ function createAuth(env?: CloudflareBindings, cf?: IncomingRequestCfProperties, 
                       }
                     : undefined,
                 kv: env?.KV,
+                ...(env?.EMAIL
+                    ? {
+                          email: {
+                              binding: env.EMAIL,
+                              from: env.BETTER_AUTH_EMAIL_FROM,
+                          },
+                      }
+                    : {}),
             },
             {
                 emailAndPassword: {
                     enabled: true,
+                },
+                emailVerification: {
+                    sendOnSignUp: true,
                 },
                 plugins: [anonymous()],
                 rateLimit: {

--- a/examples/hono/src/env.d.ts
+++ b/examples/hono/src/env.d.ts
@@ -1,8 +1,10 @@
-import type { D1Database, KVNamespace } from "@cloudflare/workers-types";
+import type { D1Database, KVNamespace, SendEmail } from "@cloudflare/workers-types";
 
 export interface CloudflareBindings {
     DATABASE: D1Database;
     KV: KVNamespace<string>;
+    EMAIL: SendEmail;
     BETTER_AUTH_SECRET: string;
     BETTER_AUTH_URL: string;
+    BETTER_AUTH_EMAIL_FROM: string;
 }

--- a/examples/hono/wrangler.toml
+++ b/examples/hono/wrangler.toml
@@ -22,6 +22,12 @@ migrations_dir = "drizzle"
 binding = "KV"
 id = "YOUR_KV_NAMESPACE_ID"
 
+[[send_email]]
+name = "EMAIL"
+
+[vars]
+BETTER_AUTH_EMAIL_FROM = "noreply@example.com"
+
 # To protect the database id and kv id, we ignore this
 # file when committing to the repo by running once:
 # git update-index --assume-unchanged wrangler.toml

--- a/examples/opennextjs/env.d.ts
+++ b/examples/opennextjs/env.d.ts
@@ -2,15 +2,17 @@
 // Uses module imports so that KVNamespace / D1Database resolve to the same
 // declaration path the better-auth-cloudflare plugin expects.
 
-import type { D1Database, KVNamespace, R2Bucket } from "@cloudflare/workers-types";
+import type { D1Database, KVNamespace, R2Bucket, SendEmail } from "@cloudflare/workers-types";
 
 declare global {
     interface CloudflareEnv {
         DATABASE: D1Database;
         KV: KVNamespace<string>;
+        EMAIL: SendEmail;
         R2_BUCKET: R2Bucket;
         BETTER_AUTH_SECRET: string;
         BETTER_AUTH_URL: string;
+        BETTER_AUTH_EMAIL_FROM: string;
         BETTER_AUTH_TRUSTED_ORIGINS: string;
     }
 }

--- a/examples/opennextjs/src/auth/index.ts
+++ b/examples/opennextjs/src/auth/index.ts
@@ -24,10 +24,14 @@ async function authBuilder() {
                 // Make sure "KV" is the binding in your wrangler.toml
                 kv: cfCtx.env.KV,
                 // Cloudflare Email Sending for verification and password reset emails
-                email: {
-                    binding: cfCtx.env.EMAIL,
-                    from: cfCtx.env.BETTER_AUTH_EMAIL_FROM,
-                },
+                ...(cfCtx.env.EMAIL
+                    ? {
+                          email: {
+                              binding: cfCtx.env.EMAIL,
+                              from: cfCtx.env.BETTER_AUTH_EMAIL_FROM,
+                          },
+                      }
+                    : {}),
                 // R2 configuration for file storage (R2_BUCKET binding from wrangler.toml)
                 r2: {
                     bucket: cfCtx.env.R2_BUCKET,

--- a/examples/opennextjs/src/auth/index.ts
+++ b/examples/opennextjs/src/auth/index.ts
@@ -23,6 +23,11 @@ async function authBuilder() {
                 },
                 // Make sure "KV" is the binding in your wrangler.toml
                 kv: cfCtx.env.KV,
+                // Cloudflare Email Sending for verification and password reset emails
+                email: {
+                    binding: cfCtx.env.EMAIL,
+                    from: cfCtx.env.BETTER_AUTH_EMAIL_FROM,
+                },
                 // R2 configuration for file storage (R2_BUCKET binding from wrangler.toml)
                 r2: {
                     bucket: cfCtx.env.R2_BUCKET,
@@ -70,6 +75,12 @@ async function authBuilder() {
             {
                 baseURL: cfCtx.env.BETTER_AUTH_URL,
                 trustedOrigins: (cfCtx.env.BETTER_AUTH_TRUSTED_ORIGINS ?? "").split(",").filter(Boolean),
+                emailAndPassword: {
+                    enabled: true,
+                },
+                emailVerification: {
+                    sendOnSignUp: true,
+                },
                 rateLimit: {
                     enabled: true,
                     window: 60, // Minimum KV TTL is 60s

--- a/examples/opennextjs/wrangler.toml
+++ b/examples/opennextjs/wrangler.toml
@@ -29,3 +29,9 @@ id = "YOUR_KV_NAMESPACE_ID"
 [[r2_buckets]]
 binding = "R2_BUCKET"
 bucket_name = "your-r2-bucket-name"
+
+[[send_email]]
+name = "EMAIL"
+
+[vars]
+BETTER_AUTH_EMAIL_FROM = "noreply@example.com"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "better-auth-cloudflare",
     "version": "0.3.0",
     "type": "module",
-    "description": "Seamlessly integrate better-auth with Cloudflare Workers, D1, Hyperdrive, KV, R2, and geolocation services.",
+    "description": "Seamlessly integrate better-auth with Cloudflare Workers, D1, Hyperdrive, KV, R2, Email, and geolocation services.",
     "author": "Zach Grimaldi",
     "repository": {
         "type": "git",
@@ -20,6 +20,7 @@
         "kv",
         "d1",
         "r2",
+        "email",
         "files",
         "storage"
     ],

--- a/src/email.ts
+++ b/src/email.ts
@@ -70,7 +70,9 @@ export function createEmailOptions<T extends BetterAuthOptions>(
 
     const sender = createEmailSender(email);
     const emailVerification: EmailVerificationOptions = { ...(options.emailVerification ?? {}) };
-    const emailAndPassword: EmailAndPasswordOptions = { enabled: true, ...(options.emailAndPassword ?? {}) };
+    const emailAndPassword: EmailAndPasswordOptions | undefined = options.emailAndPassword
+        ? { ...options.emailAndPassword }
+        : undefined;
 
     if (email.sendVerificationEmail !== false && !emailVerification.sendVerificationEmail) {
         emailVerification.sendVerificationEmail = async ({ user, url, token }, request) => {
@@ -87,7 +89,7 @@ export function createEmailOptions<T extends BetterAuthOptions>(
         };
     }
 
-    if (email.sendResetPassword !== false && !emailAndPassword.sendResetPassword) {
+    if (emailAndPassword && email.sendResetPassword !== false && !emailAndPassword.sendResetPassword) {
         emailAndPassword.sendResetPassword = async ({ user, url, token }, request) => {
             const content = await (email.templates?.passwordReset ?? defaultPasswordResetTemplate)({
                 user,

--- a/src/email.ts
+++ b/src/email.ts
@@ -49,8 +49,8 @@ function defaultPasswordResetTemplate({ url }: CloudflareEmailTemplateContext): 
     const escapedUrl = escapeHtml(url);
     return {
         subject: "Reset your password",
-        text: `Reset your password by opening this link: ${url}`,
-        html: `<p>Reset your password by opening this link:</p><p><a href="${escapedUrl}">${escapedUrl}</a></p>`,
+        text: `Reset your password by opening this link: ${url}\n\nIf you didn't request this, ignore this email.`,
+        html: `<p>Reset your password by opening this link:</p><p><a href="${escapedUrl}">${escapedUrl}</a></p><p>If you didn't request this, ignore this email.</p>`,
     };
 }
 

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,0 +1,109 @@
+import { type BetterAuthOptions } from "better-auth";
+import type { EmailSendResult } from "@cloudflare/workers-types";
+import type {
+    CloudflareEmailConfig,
+    CloudflareEmailContent,
+    CloudflareEmailMessage,
+    CloudflareEmailSender,
+    CloudflareEmailTemplateContext,
+} from "./types";
+export const createEmailSender = (config: CloudflareEmailConfig): CloudflareEmailSender => {
+    return async (message: CloudflareEmailMessage): Promise<EmailSendResult> => {
+        if (!message.text && !message.html) {
+            throw new Error("Cloudflare Email requires at least one of `text` or `html` content.");
+        }
+
+        return config.binding.send({
+            from: message.from ?? config.from,
+            to: message.to,
+            subject: message.subject,
+            ...((message.replyTo ?? config.replyTo) ? { replyTo: message.replyTo ?? config.replyTo } : {}),
+            ...(message.text ? { text: message.text } : {}),
+            ...(message.html ? { html: message.html } : {}),
+            ...(message.cc ? { cc: message.cc } : {}),
+            ...(message.bcc ? { bcc: message.bcc } : {}),
+            ...(message.headers ? { headers: message.headers } : {}),
+        });
+    };
+};
+
+function escapeHtml(value: string): string {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function defaultVerificationTemplate({ url }: CloudflareEmailTemplateContext): CloudflareEmailContent {
+    const escapedUrl = escapeHtml(url);
+    return {
+        subject: "Verify your email address",
+        text: `Verify your email address by opening this link: ${url}`,
+        html: `<p>Verify your email address by opening this link:</p><p><a href="${escapedUrl}">${escapedUrl}</a></p>`,
+    };
+}
+
+function defaultPasswordResetTemplate({ url }: CloudflareEmailTemplateContext): CloudflareEmailContent {
+    const escapedUrl = escapeHtml(url);
+    return {
+        subject: "Reset your password",
+        text: `Reset your password by opening this link: ${url}`,
+        html: `<p>Reset your password by opening this link:</p><p><a href="${escapedUrl}">${escapedUrl}</a></p>`,
+    };
+}
+
+type EmailVerificationOptions = NonNullable<BetterAuthOptions["emailVerification"]>;
+type EmailAndPasswordOptions = NonNullable<BetterAuthOptions["emailAndPassword"]>;
+
+export function createEmailOptions<T extends BetterAuthOptions>(
+    email: CloudflareEmailConfig | undefined,
+    options: T
+): Pick<BetterAuthOptions, "emailVerification" | "emailAndPassword"> {
+    if (!email) {
+        return {
+            emailVerification: options.emailVerification,
+            emailAndPassword: options.emailAndPassword,
+        };
+    }
+
+    const sender = createEmailSender(email);
+    const emailVerification: EmailVerificationOptions = { ...(options.emailVerification ?? {}) };
+    const emailAndPassword: EmailAndPasswordOptions = { enabled: true, ...(options.emailAndPassword ?? {}) };
+
+    if (email.sendVerificationEmail !== false && !emailVerification.sendVerificationEmail) {
+        emailVerification.sendVerificationEmail = async ({ user, url, token }, request) => {
+            const content = await (email.templates?.verification ?? defaultVerificationTemplate)({
+                user,
+                url,
+                token,
+                request,
+            });
+            await sender({
+                to: user.email,
+                ...content,
+            });
+        };
+    }
+
+    if (email.sendResetPassword !== false && !emailAndPassword.sendResetPassword) {
+        emailAndPassword.sendResetPassword = async ({ user, url, token }, request) => {
+            const content = await (email.templates?.passwordReset ?? defaultPasswordResetTemplate)({
+                user,
+                url,
+                token,
+                request,
+            });
+            await sender({
+                to: user.email,
+                ...content,
+            });
+        };
+    }
+
+    return {
+        emailVerification,
+        emailAndPassword,
+    };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,14 @@ import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { createAuthEndpoint, getSessionFromCtx } from "better-auth/api";
 import { schema } from "./schema";
 import { createR2Storage, createR2Endpoints } from "./r2";
+import { createEmailOptions } from "./email";
 import type { D1Database, KVNamespace } from "@cloudflare/workers-types";
 import type { CloudflareGeolocation, CloudflarePluginOptions, WithCloudflareOptions } from "./types";
 export * from "./client";
 export * from "./schema";
 export * from "./types";
 export * from "./r2";
+export * from "./email";
 
 /**
  * Cloudflare integration for Better Auth
@@ -229,9 +231,11 @@ export const withCloudflare = <T extends BetterAuthOptions>(
     }
 
     const plugins = [cloudflare(cloudFlareOptions), ...(options.plugins ?? [])] as MergedPlugins<T>;
+    const emailOptions = createEmailOptions(cloudFlareOptions.email, options);
 
     return {
         ...options,
+        ...emailOptions,
         database,
         secondaryStorage: cloudFlareOptions.kv ? createKVStorage(cloudFlareOptions.kv) : undefined,
         plugins,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,14 @@
 import type { AuthContext, Session, User } from "better-auth";
 import type { DrizzleAdapterConfig } from "@better-auth/drizzle-adapter";
 import type { DBFieldAttribute } from "better-auth/db";
-import type { D1Database, KVNamespace, R2Bucket } from "@cloudflare/workers-types";
+import type {
+    D1Database,
+    EmailAddress,
+    EmailSendResult,
+    KVNamespace,
+    R2Bucket,
+    SendEmail,
+} from "@cloudflare/workers-types";
 import type { drizzle as d1Drizzle } from "drizzle-orm/d1";
 import type { drizzle as mysqlDrizzle } from "drizzle-orm/mysql2";
 import type { drizzle as postgresDrizzle } from "drizzle-orm/postgres-js";
@@ -74,6 +81,80 @@ export interface WithCloudflareOptions extends CloudflarePluginOptions {
      * KV namespace for secondary storage, if you want to use that.
      */
     kv?: KVNamespace;
+
+    /**
+     * Cloudflare Email Sending configuration for Better Auth transactional emails.
+     * When provided, withCloudflare wires default verification and password reset
+     * callbacks unless custom callbacks are already configured in Better Auth.
+     */
+    email?: CloudflareEmailConfig;
+}
+
+export type CloudflareEmailAddress = string | EmailAddress;
+
+export interface CloudflareEmailTemplateContext {
+    user: User;
+    url: string;
+    token: string;
+    request?: Request;
+}
+
+export interface CloudflareEmailContent {
+    subject: string;
+    text?: string;
+    html?: string;
+}
+
+export type CloudflareEmailTemplate = (
+    context: CloudflareEmailTemplateContext
+) => CloudflareEmailContent | Promise<CloudflareEmailContent>;
+
+export interface CloudflareEmailMessage extends CloudflareEmailContent {
+    to: string | string[];
+    from?: CloudflareEmailAddress;
+    replyTo?: CloudflareEmailAddress;
+    cc?: string | string[];
+    bcc?: string | string[];
+    headers?: Record<string, string>;
+}
+
+export type CloudflareEmailSender = (message: CloudflareEmailMessage) => Promise<EmailSendResult>;
+
+export interface CloudflareEmailConfig {
+    /**
+     * Cloudflare Email Sending binding from wrangler.toml.
+     */
+    binding: SendEmail;
+
+    /**
+     * Default sender address. The domain must be onboarded in Cloudflare Email Service.
+     */
+    from: CloudflareEmailAddress;
+
+    /**
+     * Optional default Reply-To address for transactional emails.
+     */
+    replyTo?: CloudflareEmailAddress;
+
+    /**
+     * Set to false to avoid auto-wiring Better Auth email verification.
+     * @default true
+     */
+    sendVerificationEmail?: boolean;
+
+    /**
+     * Set to false to avoid auto-wiring Better Auth password reset emails.
+     * @default true
+     */
+    sendResetPassword?: boolean;
+
+    /**
+     * Optional custom message templates for Better Auth transactional emails.
+     */
+    templates?: {
+        verification?: CloudflareEmailTemplate;
+        passwordReset?: CloudflareEmailTemplate;
+    };
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR implements the Cloudflare Email roadmap item by adding a typed Email Sending integration for Better Auth transactional emails.

## What changed

- Added Cloudflare Email sender helpers and types:
  - `createEmailSender`
  - `createEmailOptions`
  - `CloudflareEmailConfig`
- Wired `withCloudflare` to fill Better Auth email callbacks when `email` is configured:
  - email verification
  - password reset
- Added CLI generation support for Email:
  - `--email`
  - `--email-binding`
  - `--email-from`
- Generated the correct Wrangler Email Sending TOML shape:

  ```toml
  [[send_email]]
  name = "EMAIL"
  ```

- Updated Hono and OpenNext examples with Email bindings, env typings, and auth config.
- Updated README, CLI README, configuration reference, and package metadata.
- Added Bun test coverage for Email helpers and CLI generation.
- Fixed CLI TypeScript validation to prefer the local TypeScript compiler.

## Validation

- Root typecheck passed: `npm run typecheck`
- CLI typecheck passed: `npm run typecheck` in `cli`
- Targeted CLI Bun tests passed: `89 pass, 0 fail`
- Wrangler TOML Email binding shape was validated against generated/example configs.

## Notes

- The sender address configured through `BETTER_AUTH_EMAIL_FROM` must belong to a domain configured in Cloudflare Email Service.
- Existing user-provided Better Auth email callbacks are preserved; the Cloudflare defaults are only added when callbacks are missing.
