### PR TITLE
fix: support @cloudflare/workers-types v5 (widen peer to >=4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     },
     "peerDependencies": {
         "@better-auth/drizzle-adapter": "^1.5.0",
-        "@cloudflare/workers-types": "^4.0.0",
+        "@cloudflare/workers-types": ">=4",
         "better-auth": "^1.5.0"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary

Widens the `@cloudflare/workers-types` peerDependency from `^4.0.0` to `>=4` so the library installs cleanly for consumers on current `wrangler` (4.108+ peers `workers-types@5`, which the old pin made unresolvable). Closes #58.

## Validation

Clean clone (pnpm 10.10.0 / Node 20), mirroring what `build.yml` checks:

| Check | workers-types@4 (`4.20260405.1`) | workers-types@5 (`5.20260721.1`) |
| --- | --- | --- |
| `pnpm build` | ✅ exit 0 | ✅ exit 0 |
| `pnpm typecheck` | ✅ exit 0 | ✅ exit 0 |

v5's only breaking change is the removal of dated entrypoints, which this library never imported — it consumes only stable type-only binding types (`D1Database`, `KVNamespace`, `R2Bucket`, `IncomingRequestCfProperties`). Fully backward-compatible: v4 remains supported, `>=4` only adds v5.

Root cause + reproduction in #58.
