### PR TITLE
docs: warn that KV secondary storage delays session revocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Demo implementations are available in the [`examples/`](./examples/) directory f
     - [3. Configure Better Auth (`src/auth/index.ts`)](#3-configure-better-auth-srcauthindexts)
     - [4. Generate and Manage Auth Schema](#4-generate-and-manage-auth-schema)
     - [5. Configure KV as Secondary Storage (Optional)](#5-configure-kv-as-secondary-storage-optional)
+        - [Important: KV and session revocation](#important-kv-and-session-revocation)
     - [6. Set Up API Routes](#6-set-up-api-routes)
     - [7. Initialize the Client](#7-initialize-the-client)
 - [Usage Examples](#usage-examples)
@@ -400,6 +401,26 @@ For integrating the generated `auth.schema.ts` with your existing Drizzle schema
 If you provide a KV namespace in the `withCloudflare` configuration (as shown in `src/auth/index.ts`), it will be used as [Secondary Storage](https://www.better-auth.com/docs/concepts/database#secondary-storage) by Better Auth. This is typically used for caching or storing session data that doesn't need to reside in your primary database.
 
 Ensure your KV namespace (e.g., `USER_SESSIONS`) is correctly bound in your `wrangler.toml` file.
+
+#### Important: KV and session revocation
+
+Better Auth resolves a session by checking secondary storage **before** the database, and returns immediately on a hit without consulting the database:
+
+```js
+// better-auth: internal-adapter, findSession
+if (secondaryStorage) {
+    const sessionStringified = await secondaryStorage.get(token);
+    if (sessionStringified) {
+        // returns here; the database is never consulted
+    }
+}
+```
+
+Workers KV is [eventually consistent](https://developers.cloudflare.com/kv/concepts/how-kv-works/). Changes may take 60 seconds or more to appear in another location. A stale positive session hit therefore bypasses the mirrored database after logout or another direct token revocation.
+
+Better Auth also maintains each user's active-session list with separate secondary-storage reads and writes. Concurrent session changes can lose a token reference, so bulk revocation, role or ban changes, or user deletion may miss that cached token until its original session expiry. A strongly consistent secondary store removes KV propagation lag for direct token reads and deletes, but it does not make the active-session update atomic.
+
+`session.storeSessionInDatabase: true` does not repair a stale positive hit. If bulk revocation, role or ban changes, or user deletion must take effect immediately everywhere, omit secondary session caching and leave `session.cookieCache` disabled unless Better Auth adds an atomic active-list update.
 
 #### Better Auth 1.7 atomic storage requirements
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,14 @@ This is a cost and latency choice, not a transparent compatibility shim. Databas
 
 Database-backed rate limiting requires Better Auth's rate-limit table. Generate the schema with the same 1.7 `auth` package version you deploy. For a populated 1.6 database, follow the migration process below instead of applying a plain generated schema.
 
+### KV session consistency
+
+Better Auth accepts a positive secondary-storage session without checking the mirrored database. Workers KV changes may take 60 seconds or more to appear in another location, so logout and other direct token revocations can lag.
+
+Better Auth also updates each user's active-session list with separate secondary-storage reads and writes. Concurrent session changes can lose a token reference. Bulk revocation, role or ban changes, or user deletion may then miss that cached token until its original session expiry. A strongly consistent full secondary store removes KV propagation lag for direct token reads and deletes, but it does not make the active-session update atomic.
+
+`session.storeSessionInDatabase: true` does not repair a stale positive hit. Strict bulk revocation and immediate user or authorization changes require omitting secondary session caching and leaving `session.cookieCache` disabled unless Better Auth adds an atomic active-list update.
+
 ### `createKVStorage(kv)`
 
 `createKVStorage()` exposes the `get`, `set`, and `delete` operations Workers KV can actually provide. It intentionally does not claim Better Auth 1.7's full `SecondaryStorage` contract. For Better Auth 1.7, use `withCloudflare()` as shown above. Manual wiring remains available for Better Auth 1.5 and 1.6:

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,17 @@ export interface WithCloudflareOptions extends CloudflarePluginOptions {
      * `increment` operations. When using KV with Better Auth 1.7, configure
      * `verification.storeInDatabase: true` and route rate limiting to
      * `database`, `memory`, or `customStorage` explicitly.
+     *
+     * Better Auth accepts a positive secondary-storage session without checking
+     * the database. KV changes may take 60 seconds or more to appear in another
+     * location. Better Auth also updates each user's active-session list with
+     * separate reads and writes, so concurrent changes can lose a token
+     * reference until the session expires.
+     *
+     * For strict bulk revocation or immediate user changes, leave this unset
+     * and leave `session.cookieCache` disabled.
+     *
+     * @see https://developers.cloudflare.com/kv/concepts/how-kv-works/
      */
     kv?: KVNamespace;
 


### PR DESCRIPTION
Addresses #61.

This PR is now stacked on #63, which adds Better Auth 1.7 compatibility and deterministic CI lockfiles. The original contributor commit was replayed on that foundation with authorship preserved.

## Verified behavior

Better Auth checks secondary storage before the database when resolving a session. A positive secondary-storage hit returns without consulting the mirrored database. Workers KV changes may take 60 seconds or more to appear in another location, so a stale positive session can survive logout or another direct token revocation.

storeSessionInDatabase does not repair that stale positive hit. It changes database mirroring and miss behavior, not the positive-hit path.

The audit found a second limitation beyond the original report. Better Auth updates each user's active-session list with separate secondary-storage reads and writes. Concurrent session changes can lose a token reference. Bulk revocation, role or ban changes, or user deletion can then miss the cached token until its original session expiry.

A strongly consistent full secondary store removes KV propagation lag for direct token reads and deletes. It does not make Better Auth's active-session update atomic. Strict bulk revocation and immediate user changes require omitting secondary session caching and leaving the cookie cache disabled unless Better Auth adds an atomic active-list update.

## Documentation changes

- Adds the session consistency warning next to the KV setup.
- Adds the same warning to the configuration reference.
- Expands the KV option JSDoc.
- Uses Cloudflare's exact 60 seconds or more consistency wording.
- Keeps the separate Better Auth 1.7 atomic-storage and D1 cost guidance in #63.

## Why this remains documentation

KV is already an explicit option. Another flag that only disables KV would duplicate omitting the binding. The kvAtomicCompatibility option in #63 validates Better Auth 1.7 verification and rate-limit routing, but it cannot change session lookup semantics inside Better Auth.

## Verification

- Better Auth 1.7.2 build passes.
- All 6 storage unit tests pass.
- Typecheck passes.
- The branch includes #63's frozen lockfiles and compatibility canaries for 1.5.6 and 1.6.30.

Merge #63 first. Once main contains that commit, GitHub will reduce this PR to the three documentation files.