### PR TITLE
chore: verify example migrations in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sql text eol=lf

--- a/.github/workflows/build-hono-example.yml
+++ b/.github/workflows/build-hono-example.yml
@@ -6,7 +6,9 @@ on:
         paths:
             - "package.json"
             - "pnpm-lock.yaml"
+            - ".prettierignore"
             - "src/**"
+            - "scripts/**"
             - "tsconfig.json"
             - "examples/hono/**"
             - ".github/workflows/build-hono-example.yml" # This file
@@ -15,7 +17,9 @@ on:
         paths:
             - "package.json"
             - "pnpm-lock.yaml"
+            - ".prettierignore"
             - "src/**"
+            - "scripts/**"
             - "tsconfig.json"
             - "examples/hono/**"
             - ".github/workflows/build-hono-example.yml" # This file
@@ -27,6 +31,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -48,6 +54,21 @@ jobs:
             - name: Install example dependencies
               working-directory: examples/hono
               run: pnpm install --frozen-lockfile
+
+            - name: Verify generated auth schema and migration chain
+              working-directory: examples/hono
+              env:
+                  MIGRATION_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+              run: |
+                  node ../../scripts/verify-migration-history.mjs "$MIGRATION_BASE" .
+                  pnpm auth:update
+                  pnpm db:generate
+                  pnpm exec drizzle-kit check
+                  pnpm db:check
+                  git status --short --untracked-files=all -- src/db/auth.schema.ts drizzle
+                  git diff --exit-code -- src/db/auth.schema.ts drizzle
+                  test -z "$(git ls-files --others --exclude-standard -- src/db/auth.schema.ts drizzle)"
+                  pnpm db:migrate:dev
 
             - name: Build Hono example
               working-directory: examples/hono

--- a/.github/workflows/build-opennextjs-example.yml
+++ b/.github/workflows/build-opennextjs-example.yml
@@ -6,7 +6,9 @@ on:
         paths:
             - "package.json"
             - "pnpm-lock.yaml"
+            - ".prettierignore"
             - "src/**"
+            - "scripts/**"
             - "tsconfig.json"
             - "examples/opennextjs/**"
             - ".github/workflows/build-opennextjs-example.yml" # This file
@@ -15,7 +17,9 @@ on:
         paths:
             - "package.json"
             - "pnpm-lock.yaml"
+            - ".prettierignore"
             - "src/**"
+            - "scripts/**"
             - "tsconfig.json"
             - "examples/opennextjs/**"
             - ".github/workflows/build-opennextjs-example.yml" # This file
@@ -27,6 +31,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -48,6 +54,25 @@ jobs:
             - name: Install example dependencies
               working-directory: examples/opennextjs
               run: pnpm install --frozen-lockfile
+
+            - name: Verify generated auth schema and migration chain
+              working-directory: examples/opennextjs
+              env:
+                  MIGRATION_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+              run: |
+                  node ../../scripts/verify-migration-history.mjs "$MIGRATION_BASE" .
+                  pnpm auth:update
+                  pnpm db:generate
+                  pnpm exec drizzle-kit check
+                  pnpm db:check
+                  git status --short --untracked-files=all -- src/db/auth.schema.ts drizzle
+                  git diff --exit-code -- src/db/auth.schema.ts drizzle
+                  test -z "$(git ls-files --others --exclude-standard -- src/db/auth.schema.ts drizzle)"
+                  pnpm db:migrate:dev
+
+            - name: Typecheck Example (OpenNextJS)
+              working-directory: examples/opennextjs
+              run: pnpm typecheck
 
             - name: Build Example (OpenNextJS)
               working-directory: examples/opennextjs

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ node_modules
 dist
 build
 .wrangler
+examples/*/drizzle

--- a/examples/hono/.prettierignore
+++ b/examples/hono/.prettierignore
@@ -8,4 +8,5 @@ bun.lockb
 node_modules
 dist
 build
-.wranglerdrizzle
+.wrangler
+drizzle

--- a/examples/hono/.prettierignore
+++ b/examples/hono/.prettierignore
@@ -8,4 +8,4 @@ bun.lockb
 node_modules
 dist
 build
-.wrangler
+.wranglerdrizzle

--- a/examples/hono/package.json
+++ b/examples/hono/package.json
@@ -12,7 +12,8 @@
         "db:migrate:dev": "wrangler d1 migrations apply DATABASE --local",
         "db:migrate:prod": "wrangler d1 migrations apply DATABASE --remote",
         "db:studio:dev": "drizzle-kit studio",
-        "db:studio:prod": "NODE_ENV=production drizzle-kit studio"
+        "db:studio:prod": "NODE_ENV=production drizzle-kit studio",
+        "db:check": "node ../../scripts/verify-sqlite-migrations.mjs"
     },
     "dependencies": {
         "@better-auth/drizzle-adapter": "1.6.30",
@@ -24,7 +25,7 @@
     },
     "devDependencies": {
         "@types/node": "^22.15.30",
-        "drizzle-kit": "^0.31.1",
+        "drizzle-kit": "0.31.10",
         "typescript": "^5.8.3",
         "wrangler": "4.127.1"
     },

--- a/examples/hono/pnpm-lock.yaml
+++ b/examples/hono/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         specifier: ^22.15.30
         version: 22.19.17
       drizzle-kit:
-        specifier: ^0.31.1
+        specifier: 0.31.10
         version: 0.31.10
       typescript:
         specifier: ^5.8.3

--- a/examples/opennextjs/.prettierignore
+++ b/examples/opennextjs/.prettierignore
@@ -8,4 +8,5 @@ bun.lockb
 node_modules
 dist
 build
-.wranglerdrizzle
+.wrangler
+drizzle

--- a/examples/opennextjs/.prettierignore
+++ b/examples/opennextjs/.prettierignore
@@ -8,4 +8,4 @@ bun.lockb
 node_modules
 dist
 build
-.wrangler
+.wranglerdrizzle

--- a/examples/opennextjs/package.json
+++ b/examples/opennextjs/package.json
@@ -20,7 +20,9 @@
         "db:migrate:dev": "wrangler d1 migrations apply DATABASE --local",
         "db:migrate:prod": "wrangler d1 migrations apply DATABASE --remote",
         "db:studio:dev": "drizzle-kit studio",
-        "db:studio:prod": "NODE_ENV=production drizzle-kit studio"
+        "db:studio:prod": "NODE_ENV=production drizzle-kit studio",
+        "db:check": "node ../../scripts/verify-sqlite-migrations.mjs",
+        "typecheck": "tsc --noEmit"
     },
     "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
@@ -47,7 +49,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "autoprefixer": "^10.4.20",
-        "drizzle-kit": "^0.31.0",
+        "drizzle-kit": "0.31.10",
         "postcss": "^8.4.35",
         "prettier": "^3.5.3",
         "tailwindcss": "^3.4.15",

--- a/examples/opennextjs/pnpm-lock.yaml
+++ b/examples/opennextjs/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         version: 1.1.12(@types/react-dom@19.1.3(@types/react@19.1.3))(@types/react@19.1.3)(react-dom@19.1.9(react@19.1.9))(react@19.1.9)
       better-auth:
         specifier: 1.6.30
-        version: 1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.4)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9)
+        version: 1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9)
       better-auth-cloudflare:
         specifier: file:../../
-        version: file:../..(@better-auth/drizzle-adapter@1.6.30(@better-auth/core@1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.5)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5)))(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-auth@1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.4)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(kysely@0.29.5)
+        version: file:../..(@better-auth/drizzle-adapter@1.6.30(@better-auth/core@1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.5)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5)))(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-auth@1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(kysely@0.29.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -82,8 +82,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.23)
       drizzle-kit:
-        specifier: ^0.31.0
-        version: 0.31.4
+        specifier: 0.31.10
+        version: 0.31.10
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -2172,8 +2172,8 @@ packages:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
 
-  drizzle-kit@0.31.4:
-    resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
 
   drizzle-orm@0.45.2:
@@ -2323,11 +2323,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  esbuild-register@3.6.0:
-    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
-    peerDependencies:
-      esbuild: '>=0.12 <1'
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
@@ -3171,6 +3166,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -5122,11 +5122,11 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  better-auth-cloudflare@file:../..(@better-auth/drizzle-adapter@1.6.30(@better-auth/core@1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.5)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5)))(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-auth@1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.4)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(kysely@0.29.5):
+  better-auth-cloudflare@file:../..(@better-auth/drizzle-adapter@1.6.30(@better-auth/core@1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.5)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5)))(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-auth@1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(kysely@0.29.5):
     dependencies:
       '@better-auth/drizzle-adapter': 1.6.30(@better-auth/core@1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.5)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))
       '@cloudflare/workers-types': 5.20260830.1
-      better-auth: 1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.4)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9)
+      better-auth: 1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9)
       drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5)
       mime: 4.1.0
       zod: 4.3.6
@@ -5160,7 +5160,7 @@ snapshots:
       - sql.js
       - sqlite3
 
-  better-auth@1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.4)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9):
+  better-auth@1.6.30(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))(next@15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9))(react-dom@19.1.9(react@19.1.9))(react@19.1.9):
     dependencies:
       '@better-auth/core': 1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.5)(nanostores@1.2.0)
       '@better-auth/drizzle-adapter': 1.6.30(@better-auth/core@1.6.30(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.3.6))(jose@6.2.2)(kysely@0.29.5)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5))
@@ -5180,7 +5180,7 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      drizzle-kit: 0.31.4
+      drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5)
       next: 15.5.24(@opentelemetry/api@1.9.1)(@types/node@20.17.46)(react-dom@19.1.9(react@19.1.9))(react@19.1.9)
       react: 19.1.9
@@ -5368,14 +5368,12 @@ snapshots:
 
   dotenv@16.5.0: {}
 
-  drizzle-kit@0.31.4:
+  drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
       '@esbuild-kit/esm-loader': 2.6.5
       esbuild: 0.25.4
-      esbuild-register: 3.6.0(esbuild@0.25.4)
-    transitivePeerDependencies:
-      - supports-color
+      tsx: 4.23.13
 
   drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260830.1)(@opentelemetry/api@1.9.1)(kysely@0.29.5):
     optionalDependencies:
@@ -5433,13 +5431,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  esbuild-register@3.6.0(esbuild@0.25.4):
-    dependencies:
-      debug: 4.4.0
-      esbuild: 0.25.4
-    transitivePeerDependencies:
-      - supports-color
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -6392,6 +6383,12 @@ snapshots:
   ts-tqdm@0.8.6: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.23.13:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-is@2.0.1:
     dependencies:

--- a/examples/opennextjs/tsconfig.json
+++ b/examples/opennextjs/tsconfig.json
@@ -20,8 +20,7 @@
         ],
         "paths": {
             "@/*": ["./src/*"]
-        },
-        "preserveSymlinks": true
+        }
     },
     "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
     "exclude": ["node_modules"]

--- a/scripts/drizzle-snapshot-safety.mjs
+++ b/scripts/drizzle-snapshot-safety.mjs
@@ -1,0 +1,48 @@
+export function normalizeDrizzleSnapshot(snapshot) {
+    const parsed = typeof snapshot === "string" ? JSON.parse(snapshot) : snapshot;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("Drizzle snapshot must be a JSON object.");
+    }
+    const { id: _generatedId, ...stableSnapshot } = parsed;
+    return JSON.stringify(sortJson(stableSnapshot));
+}
+
+export function assertDrizzleSnapshotsMatch(committed, reproduced, filename) {
+    if (normalizeDrizzleSnapshot(committed) !== normalizeDrizzleSnapshot(reproduced)) {
+        throw new Error(
+            `The latest snapshot does not match Drizzle Kit output. Regenerate ${filename} instead of editing generated migration state by hand.`
+        );
+    }
+}
+
+export function normalizeGeneratedSql(sql) {
+    return sql.replaceAll(/\n+$/g, "");
+}
+
+export function assertDrizzleJournalEntriesMatch(committed, reproduced, filename) {
+    const committedEntry = parseObject(committed, "Committed Drizzle journal entry");
+    const reproducedEntry = parseObject(reproduced, "Reproduced Drizzle journal entry");
+    const { tag: _committedTag, when: _committedWhen, ...committedShape } = committedEntry;
+    const { tag: _reproducedTag, when: _reproducedWhen, ...reproducedShape } = reproducedEntry;
+    if (JSON.stringify(sortJson(committedShape)) !== JSON.stringify(sortJson(reproducedShape))) {
+        throw new Error(
+            `The latest journal entry does not match Drizzle Kit output. Regenerate ${filename} instead of editing generated migration state by hand.`
+        );
+    }
+}
+
+function sortJson(value) {
+    if (Array.isArray(value)) return value.map(sortJson);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(
+        Object.keys(value)
+            .sort()
+            .map(key => [key, sortJson(value[key])])
+    );
+}
+
+function parseObject(value, label) {
+    const parsed = typeof value === "string" ? JSON.parse(value) : value;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(`${label} must be an object.`);
+    return parsed;
+}

--- a/scripts/sql-migration-safety.mjs
+++ b/scripts/sql-migration-safety.mjs
@@ -1,0 +1,148 @@
+export function rejectUnsafeDml(migration, sql) {
+    for (const statement of splitAtBreakpoints(sql)) {
+        const { clean, classification } = sanitizeSql(statement);
+        const trimmed = clean.trim();
+        if (
+            !/\b(?:DELETE\s+FROM|UPDATE\s+[^;]+\s+SET|INSERT(?:\s+OR\s+(?:ROLLBACK|ABORT|FAIL|IGNORE|REPLACE))?\s+INTO|REPLACE\s+INTO)\b/i.test(
+                classification
+            )
+        ) {
+            continue;
+        }
+
+        const drizzleTableCopy =
+            /^INSERT\s+INTO\s+(?:`__new_[^`]+`|"__new_[^"]+")\s*\([^;]*\)\s+SELECT\s+[^;]+\s+FROM\s+(?:`[^`]+`|"[^"]+")\s*;?\s*$/is;
+        if (!drizzleTableCopy.test(trimmed)) {
+            throw new Error(`${migration} contains data-changing SQL that is not a single Drizzle table-rebuild copy.`);
+        }
+    }
+}
+
+function splitAtBreakpoints(sql) {
+    const statements = [];
+    let current = "";
+    let quote = null;
+    let comment = null;
+
+    for (let index = 0; index < sql.length; index += 1) {
+        const character = sql[index];
+        const next = sql[index + 1];
+
+        if (comment === "line") {
+            current += character;
+            if (character === "\n" || character === "\r") comment = null;
+            continue;
+        }
+        if (comment === "block") {
+            current += character;
+            if (character === "*" && next === "/") {
+                current += next;
+                index += 1;
+                comment = null;
+            }
+            continue;
+        }
+        if (quote !== null) {
+            current += character;
+            if (quote === "[") {
+                if (character === "]") quote = null;
+            } else if (character === quote) {
+                if (next === quote) {
+                    current += next;
+                    index += 1;
+                } else {
+                    quote = null;
+                }
+            }
+            continue;
+        }
+
+        const breakpoint = sql.startsWith("-->", index) ? /^-->\s*statement-breakpoint/.exec(sql.slice(index)) : null;
+        if (breakpoint) {
+            statements.push(current);
+            current = "";
+            index += breakpoint[0].length - 1;
+            continue;
+        }
+        if (character === "'" || character === '"' || character === "`" || character === "[") {
+            quote = character;
+            current += character;
+            continue;
+        }
+        if (character === "-" && next === "-") {
+            comment = "line";
+            current += character;
+            continue;
+        }
+        if (character === "/" && next === "*") {
+            comment = "block";
+            current += character;
+            continue;
+        }
+        current += character;
+    }
+
+    statements.push(current);
+    return statements;
+}
+
+function sanitizeSql(sql) {
+    let clean = "";
+    let classification = "";
+    let quote = null;
+
+    for (let index = 0; index < sql.length; index += 1) {
+        const character = sql[index];
+        const next = sql[index + 1];
+
+        if (quote !== null) {
+            clean += character;
+            classification += " ";
+            if (quote === "[") {
+                if (character === "]") quote = null;
+            } else if (character === quote) {
+                if (next === quote) {
+                    clean += next;
+                    classification += " ";
+                    index += 1;
+                } else {
+                    quote = null;
+                }
+            }
+            continue;
+        }
+
+        if (character === "'" || character === '"' || character === "`") {
+            quote = character;
+            clean += character;
+            classification += " ";
+            continue;
+        }
+        if (character === "[") {
+            quote = character;
+            clean += character;
+            classification += " ";
+            continue;
+        }
+        if (character === "-" && next === "-") {
+            index += 2;
+            while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") index += 1;
+            clean += "\n";
+            classification += "\n";
+            continue;
+        }
+        if (character === "/" && next === "*") {
+            index += 2;
+            while (index < sql.length && !(sql[index] === "*" && sql[index + 1] === "/")) index += 1;
+            if (index < sql.length) index += 1;
+            clean += " ";
+            classification += " ";
+            continue;
+        }
+
+        clean += character;
+        classification += character;
+    }
+
+    return { clean, classification };
+}

--- a/scripts/verify-migration-history.mjs
+++ b/scripts/verify-migration-history.mjs
@@ -7,6 +7,7 @@ export function validateMigrationChanges(changes) {
     const errors = [];
     let addedMigrations = 0;
     let addedSnapshots = 0;
+    const addedIndexes = new Set();
 
     for (const { status, paths } of changes) {
         for (const path of paths) {
@@ -26,6 +27,7 @@ export function validateMigrationChanges(changes) {
             }
             if (isMigration) addedMigrations += 1;
             if (isSnapshot) addedSnapshots += 1;
+            addedIndexes.add(filename.slice(0, filename.indexOf("_")));
         }
     }
 
@@ -35,6 +37,8 @@ export function validateMigrationChanges(changes) {
         errors.push(
             `Generated migration and snapshot additions must match, found ${addedMigrations} migration(s) and ${addedSnapshots} snapshot(s).`
         );
+    } else if (addedIndexes.size > 1) {
+        errors.push(`The added migration and snapshot must share one index, found ${[...addedIndexes].join(", ")}.`);
     }
     return errors;
 }

--- a/scripts/verify-migration-history.mjs
+++ b/scripts/verify-migration-history.mjs
@@ -1,0 +1,147 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { basename, relative, resolve, sep } from "node:path";
+
+export function validateMigrationChanges(changes) {
+    const errors = [];
+    let addedMigrations = 0;
+    let addedSnapshots = 0;
+
+    for (const { status, paths } of changes) {
+        for (const path of paths) {
+            const filename = basename(path);
+            if (filename === "_journal.json") {
+                if (status !== "A" && status !== "M") errors.push(`Drizzle journal cannot be ${status}: ${path}`);
+                continue;
+            }
+
+            const isMigration = filename.endsWith(".sql");
+            const isSnapshot = /\d+_snapshot\.json$/.test(filename);
+            if (!isMigration && !isSnapshot) continue;
+
+            if (status !== "A") {
+                errors.push(`Existing generated migration history is immutable: ${status} ${path}`);
+                continue;
+            }
+            if (isMigration) addedMigrations += 1;
+            if (isSnapshot) addedSnapshots += 1;
+        }
+    }
+
+    if (addedMigrations > 1) errors.push(`A change may add at most one generated migration, found ${addedMigrations}.`);
+    if (addedSnapshots > 1) errors.push(`A change may add at most one generated snapshot, found ${addedSnapshots}.`);
+    if (addedMigrations !== addedSnapshots) {
+        errors.push(
+            `Generated migration and snapshot additions must match, found ${addedMigrations} migration(s) and ${addedSnapshots} snapshot(s).`
+        );
+    }
+    return errors;
+}
+
+export function validateJournalHistory(baseInput, headInput, newMigrationFilename) {
+    const errors = [];
+    let base;
+    let head;
+    try {
+        base = typeof baseInput === "string" ? JSON.parse(baseInput) : baseInput;
+        head = typeof headInput === "string" ? JSON.parse(headInput) : headInput;
+    } catch {
+        return ["Drizzle journal must contain valid JSON."];
+    }
+    if (!base || !head || !Array.isArray(base.entries) || !Array.isArray(head.entries)) {
+        return ["Drizzle journal must contain an entries array."];
+    }
+
+    const { entries: baseEntries, ...baseMetadata } = base;
+    const { entries: headEntries, ...headMetadata } = head;
+    if (!sameJson(baseMetadata, headMetadata)) errors.push("Drizzle journal metadata is immutable.");
+
+    const additions = newMigrationFilename ? 1 : 0;
+    if (headEntries.length !== baseEntries.length + additions) {
+        errors.push(`Drizzle journal must append exactly ${additions} entries.`);
+    }
+    for (let index = 0; index < baseEntries.length; index += 1) {
+        if (!sameJson(baseEntries[index], headEntries[index])) {
+            errors.push(`Existing Drizzle journal entry ${index} is immutable.`);
+        }
+    }
+
+    if (newMigrationFilename && headEntries.length > baseEntries.length) {
+        const entry = headEntries[baseEntries.length];
+        const expectedTag = newMigrationFilename.replace(/\.sql$/, "");
+        const priorIndex = baseEntries.length === 0 ? -1 : baseEntries.at(-1)?.idx;
+        if (!entry || entry.tag !== expectedTag) errors.push("The appended journal tag must match the new migration.");
+        if (!Number.isInteger(priorIndex) || entry?.idx !== priorIndex + 1) {
+            errors.push("The appended journal index must follow the existing history.");
+        }
+        if (!Number.isSafeInteger(entry?.when) || entry.when <= 0 || typeof entry?.breakpoints !== "boolean") {
+            errors.push("The appended journal entry is malformed.");
+        }
+    }
+
+    return errors;
+}
+
+function sameJson(left, right) {
+    return JSON.stringify(sortJson(left)) === JSON.stringify(sortJson(right));
+}
+
+function sortJson(value) {
+    if (Array.isArray(value)) return value.map(sortJson);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(
+        Object.keys(value)
+            .sort()
+            .map(key => [key, sortJson(value[key])])
+    );
+}
+
+function parseNameStatus(output) {
+    return output
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map(line => {
+            const [status, ...paths] = line.split("\t");
+            return { status, paths };
+        });
+}
+
+function main() {
+    const base = process.argv[2];
+    const projectDirectory = resolve(process.argv[3] ?? ".");
+    if (!base || /^0+$/.test(base)) {
+        console.log("No comparison commit is available; skipping migration-history diff check.");
+        return;
+    }
+
+    const repository = execFileSync("git", ["-C", projectDirectory, "rev-parse", "--show-toplevel"], {
+        encoding: "utf8",
+    }).trim();
+    execFileSync("git", ["-C", repository, "cat-file", "-e", `${base}^{commit}`]);
+    const projectPath = relative(repository, projectDirectory).split(sep).join("/");
+    const migrationPath = projectPath ? `${projectPath}/drizzle` : "drizzle";
+    const output = execFileSync(
+        "git",
+        ["-C", repository, "diff", "--name-status", "--find-renames", base, "--", migrationPath],
+        { encoding: "utf8" }
+    );
+    const changes = parseNameStatus(output);
+    const errors = validateMigrationChanges(changes);
+    const newMigrations = changes.flatMap(({ status, paths }) =>
+        status === "A" ? paths.filter(path => path.endsWith(".sql")).map(path => basename(path)) : []
+    );
+    const journalPath = `${migrationPath}/meta/_journal.json`;
+    const baseJournal = execFileSync("git", ["-C", repository, "show", `${base}:${journalPath}`], {
+        encoding: "utf8",
+    });
+    const headJournal = readFileSync(resolve(repository, journalPath), "utf8");
+    errors.push(
+        ...validateJournalHistory(baseJournal, headJournal, newMigrations.length === 1 ? newMigrations[0] : undefined)
+    );
+    if (errors.length > 0) throw new Error(errors.join("\n"));
+    console.log(`Verified generated migration history against ${base}.`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) main();

--- a/scripts/verify-sqlite-migrations.mjs
+++ b/scripts/verify-sqlite-migrations.mjs
@@ -1,0 +1,211 @@
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, relative, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+import { rejectUnsafeDml } from "./sql-migration-safety.mjs";
+import {
+    assertDrizzleJournalEntriesMatch,
+    assertDrizzleSnapshotsMatch,
+    normalizeGeneratedSql,
+} from "./drizzle-snapshot-safety.mjs";
+
+const projectDirectory = resolve(process.argv[2] ?? ".");
+const migrationDirectory = join(projectDirectory, "drizzle");
+const migrationDatabase = new DatabaseSync(":memory:");
+const schemaDatabase = new DatabaseSync(":memory:");
+const verificationDirectory = mkdtempSync(join(tmpdir(), "bac-drizzle-verification-"));
+
+try {
+    const migrations = readdirSync(migrationDirectory)
+        .filter(file => file.endsWith(".sql"))
+        .sort();
+    if (migrations.length === 0) throw new Error(`No migrations found in ${migrationDirectory}`);
+
+    for (const migration of migrations) {
+        const sql = readFileSync(join(migrationDirectory, migration), "utf8");
+        rejectUnsafeDml(migration, sql);
+        migrationDatabase.exec(sql);
+    }
+
+    const projectRequire = createRequire(join(projectDirectory, "package.json"));
+    const packagePath = join(dirname(projectRequire.resolve("drizzle-kit")), "package.json");
+    const drizzleKitPackage = JSON.parse(readFileSync(packagePath, "utf8"));
+    const bin =
+        typeof drizzleKitPackage.bin === "string" ? drizzleKitPackage.bin : drizzleKitPackage.bin?.["drizzle-kit"];
+    if (typeof bin !== "string") throw new Error("Cannot find the installed drizzle-kit executable.");
+    const drizzleKit = resolve(dirname(packagePath), bin);
+    verifyLatestMigrationWasGenerated({
+        drizzleKit,
+        migrations,
+        migrationDirectory,
+        projectDirectory,
+    });
+    const schemaConfigPath = writeSchemaOnlyConfig(
+        verificationDirectory,
+        projectDirectory,
+        join(verificationDirectory, "export")
+    );
+    const schemaSql = execFileSync(process.execPath, [drizzleKit, "export", `--config=${schemaConfigPath}`], {
+        cwd: projectDirectory,
+        encoding: "utf8",
+    });
+    schemaDatabase.exec(schemaSql);
+
+    const migratedSchema = inspectSchema(migrationDatabase);
+    const declaredSchema = inspectSchema(schemaDatabase);
+    if (JSON.stringify(migratedSchema) !== JSON.stringify(declaredSchema)) {
+        throw new Error(
+            `The migration chain does not match the declared Drizzle schema.\n\nMigrations:\n${JSON.stringify(migratedSchema, null, 2)}\n\nSchema:\n${JSON.stringify(declaredSchema, null, 2)}`
+        );
+    }
+
+    console.log(`Verified ${migrations.length} migrations against the declared Drizzle schema.`);
+} finally {
+    rmSync(verificationDirectory, { force: true, recursive: true });
+    migrationDatabase.close();
+    schemaDatabase.close();
+}
+
+function query(database, sql) {
+    return database
+        .prepare(sql)
+        .all()
+        .map(row => ({ ...row }));
+}
+
+function inspectSchema(database) {
+    const tables = query(
+        database,
+        "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).map(({ name }) => name);
+
+    return {
+        tables: tables.map(table => ({
+            name: table,
+            columns: query(
+                database,
+                `SELECT name, type, \"notnull\", dflt_value, pk, hidden FROM pragma_table_xinfo(${quote(table)}) ORDER BY name`
+            ),
+            foreignKeys: query(
+                database,
+                `SELECT id, seq, \"table\", \"from\", \"to\", on_update, on_delete, \"match\" FROM pragma_foreign_key_list(${quote(table)}) ORDER BY id, seq`
+            ),
+            indexes: inspectIndexes(database, table),
+        })),
+        viewsAndTriggers: query(
+            database,
+            "SELECT type, name, tbl_name, sql FROM sqlite_schema WHERE type IN ('view', 'trigger') ORDER BY type, name"
+        ).map(object => ({ ...object, sql: normalizeSql(object.sql) })),
+    };
+}
+
+function inspectIndexes(database, table) {
+    return query(
+        database,
+        `SELECT name, \"unique\", origin, partial FROM pragma_index_list(${quote(table)}) ORDER BY name`
+    ).map(index => ({
+        ...index,
+        columns: query(
+            database,
+            `SELECT seqno, name, \"desc\", coll, \"key\" FROM pragma_index_xinfo(${quote(index.name)}) ORDER BY seqno`
+        ),
+    }));
+}
+
+function quote(value) {
+    return `'${value.replaceAll("'", "''")}'`;
+}
+
+function normalizeSql(sql) {
+    return sql.replaceAll(/\s+/g, " ").trim();
+}
+
+function verifyLatestMigrationWasGenerated({ drizzleKit, migrations, migrationDirectory, projectDirectory }) {
+    const journalPath = join(migrationDirectory, "meta", "_journal.json");
+    const journal = JSON.parse(readFileSync(journalPath, "utf8"));
+    const snapshots = readdirSync(join(migrationDirectory, "meta"))
+        .filter(file => file.endsWith("_snapshot.json"))
+        .sort();
+    if (journal.entries.length !== migrations.length || snapshots.length !== migrations.length) {
+        throw new Error("The Drizzle journal, migrations, and snapshots do not have matching lengths.");
+    }
+    const latestEntry = journal.entries.at(-1);
+    if (!latestEntry || `${latestEntry.tag}.sql` !== migrations.at(-1)) {
+        throw new Error("The latest Drizzle journal entry does not match the latest migration file.");
+    }
+
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), "bac-drizzle-reproduction-"));
+    const reproducedDirectory = join(temporaryDirectory, "drizzle");
+    const reproducedMetaDirectory = join(reproducedDirectory, "meta");
+    try {
+        mkdirSync(reproducedMetaDirectory, { recursive: true });
+        for (const migration of migrations.slice(0, -1)) {
+            cpSync(join(migrationDirectory, migration), join(reproducedDirectory, migration));
+        }
+        for (const snapshot of snapshots.slice(0, -1)) {
+            cpSync(join(migrationDirectory, "meta", snapshot), join(reproducedMetaDirectory, snapshot));
+        }
+        writeFileSync(
+            join(reproducedMetaDirectory, "_journal.json"),
+            JSON.stringify({ ...journal, entries: journal.entries.slice(0, -1) }, null, 2)
+        );
+
+        const configPath = writeSchemaOnlyConfig(temporaryDirectory, projectDirectory, reproducedDirectory);
+        execFileSync(process.execPath, [drizzleKit, "generate", `--config=${configPath}`], {
+            cwd: projectDirectory,
+            encoding: "utf8",
+        });
+
+        const reproducedMigrations = readdirSync(reproducedDirectory)
+            .filter(file => file.endsWith(".sql"))
+            .sort();
+        const reproducedLatest = reproducedMigrations.at(-1);
+        if (!reproducedLatest || reproducedMigrations.length !== migrations.length) {
+            throw new Error("Drizzle did not reproduce exactly one latest migration.");
+        }
+
+        const committedSql = normalizeGeneratedSql(readFileSync(join(migrationDirectory, migrations.at(-1)), "utf8"));
+        const reproducedSql = normalizeGeneratedSql(readFileSync(join(reproducedDirectory, reproducedLatest), "utf8"));
+        if (committedSql !== reproducedSql) {
+            throw new Error(
+                `The latest migration does not match Drizzle Kit output. Regenerate ${migrations.at(-1)} instead of editing SQL by hand.`
+            );
+        }
+
+        const reproducedSnapshots = readdirSync(reproducedMetaDirectory)
+            .filter(file => file.endsWith("_snapshot.json"))
+            .sort();
+        const reproducedSnapshot = reproducedSnapshots.at(-1);
+        if (!reproducedSnapshot || reproducedSnapshots.length !== snapshots.length) {
+            throw new Error("Drizzle did not reproduce exactly one latest snapshot.");
+        }
+        assertDrizzleSnapshotsMatch(
+            readFileSync(join(migrationDirectory, "meta", snapshots.at(-1)), "utf8"),
+            readFileSync(join(reproducedMetaDirectory, reproducedSnapshot), "utf8"),
+            snapshots.at(-1)
+        );
+        const reproducedJournal = JSON.parse(readFileSync(join(reproducedMetaDirectory, "_journal.json"), "utf8"));
+        assertDrizzleJournalEntriesMatch(
+            journal.entries.at(-1),
+            reproducedJournal.entries?.at(-1),
+            "meta/_journal.json"
+        );
+    } finally {
+        rmSync(temporaryDirectory, { force: true, recursive: true });
+    }
+}
+
+function writeSchemaOnlyConfig(directory, projectDirectory, out) {
+    const configPath = join(directory, "drizzle.config.mjs");
+    writeFileSync(
+        configPath,
+        `export default ${JSON.stringify({
+            dialect: "sqlite",
+            schema: join(projectDirectory, "src", "db", "index.ts"),
+            out: relative(projectDirectory, out),
+        })};\n`
+    );
+    return configPath;
+}

--- a/test/drizzle-snapshot-safety.test.mjs
+++ b/test/drizzle-snapshot-safety.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+    assertDrizzleJournalEntriesMatch,
+    assertDrizzleSnapshotsMatch,
+    normalizeDrizzleSnapshot,
+    normalizeGeneratedSql,
+} from "../scripts/drizzle-snapshot-safety.mjs";
+
+describe("Drizzle snapshot safety", () => {
+    const snapshot = {
+        id: "generated-a",
+        prevId: "previous",
+        tables: {
+            users: {
+                columns: {
+                    email: { name: "email", notNull: true, primaryKey: false, type: "text" },
+                },
+            },
+        },
+    };
+
+    it("ignores only the generated top-level id and object key order", () => {
+        const reproduced = {
+            tables: snapshot.tables,
+            prevId: snapshot.prevId,
+            id: "generated-b",
+        };
+        assert.equal(normalizeDrizzleSnapshot(snapshot), normalizeDrizzleSnapshot(reproduced));
+    });
+
+    it("rejects schema mutations", () => {
+        const mutated = structuredClone(snapshot);
+        mutated.tables.users.columns.email.notNull = false;
+        assert.throws(
+            () => assertDrizzleSnapshotsMatch(mutated, snapshot, "0002_snapshot.json"),
+            /does not match Drizzle Kit output/
+        );
+    });
+
+    it("rejects migration-chain mutations", () => {
+        assert.throws(
+            () => assertDrizzleSnapshotsMatch({ ...snapshot, prevId: "wrong" }, snapshot, "0002_snapshot.json"),
+            /does not match Drizzle Kit output/
+        );
+    });
+
+    it("normalizes terminal newlines without changing SQL bytes", () => {
+        assert.equal(normalizeGeneratedSql("SELECT 'a  b';\n"), "SELECT 'a  b';");
+        assert.notEqual(normalizeGeneratedSql("SELECT 'a  b';\n"), normalizeGeneratedSql("SELECT 'a b';\n"));
+        assert.notEqual(normalizeGeneratedSql("SELECT 'a\r\nb';\n"), normalizeGeneratedSql("SELECT 'a\nb';\n"));
+    });
+
+    it("compares the deterministic journal entry shape", () => {
+        const committed = { idx: 2, version: "6", when: 1, tag: "0002_committed", breakpoints: true };
+        const reproduced = { ...committed, when: 2, tag: "0002_reproduced" };
+        assert.doesNotThrow(() => assertDrizzleJournalEntriesMatch(committed, reproduced, "meta/_journal.json"));
+        for (const mutation of [
+            { ...committed, version: "999" },
+            { ...committed, breakpoints: false },
+            { idx: 2, when: 1, tag: "0002_committed", breakpoints: true },
+            { ...committed, extra: true },
+        ]) {
+            assert.throws(
+                () => assertDrizzleJournalEntriesMatch(mutation, reproduced, "meta/_journal.json"),
+                /does not match Drizzle Kit output/
+            );
+        }
+    });
+});

--- a/test/migration-history-safety.test.mjs
+++ b/test/migration-history-safety.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { validateJournalHistory, validateMigrationChanges } from "../scripts/verify-migration-history.mjs";
+
+describe("migration history safety", () => {
+    it("accepts one generated migration and matching snapshot", () => {
+        assert.deepEqual(
+            validateMigrationChanges([
+                { status: "A", paths: ["examples/hono/drizzle/0002_generated.sql"] },
+                { status: "A", paths: ["examples/hono/drizzle/meta/0002_snapshot.json"] },
+                { status: "M", paths: ["examples/hono/drizzle/meta/_journal.json"] },
+            ]),
+            []
+        );
+    });
+
+    it("rejects edits and renames of existing generated history", () => {
+        const errors = validateMigrationChanges([
+            { status: "M", paths: ["examples/hono/drizzle/0001_existing.sql"] },
+            {
+                status: "R100",
+                paths: [
+                    "examples/hono/drizzle/meta/0001_snapshot.json",
+                    "examples/hono/drizzle/meta/0001_renamed_snapshot.json",
+                ],
+            },
+        ]);
+        assert.equal(errors.filter(error => error.includes("immutable")).length, 2);
+    });
+
+    it("rejects multiple or unmatched generated additions", () => {
+        const errors = validateMigrationChanges([
+            { status: "A", paths: ["examples/hono/drizzle/0002_a.sql"] },
+            { status: "A", paths: ["examples/hono/drizzle/0003_b.sql"] },
+            { status: "A", paths: ["examples/hono/drizzle/meta/0002_snapshot.json"] },
+        ]);
+        assert.ok(errors.some(error => error.includes("at most one generated migration")));
+        assert.ok(errors.some(error => error.includes("additions must match")));
+    });
+
+    it("accepts one generated journal entry", () => {
+        const base = {
+            version: "7",
+            dialect: "sqlite",
+            entries: [{ idx: 0, when: 1, tag: "0000_initial", breakpoints: true }],
+        };
+        const head = {
+            ...base,
+            entries: [...base.entries, { idx: 1, when: 2, tag: "0001_generated", breakpoints: true }],
+        };
+        assert.deepEqual(validateJournalHistory(base, head, "0001_generated.sql"), []);
+    });
+
+    it("rejects edits to journal metadata and historical entries", () => {
+        const base = {
+            version: "7",
+            dialect: "sqlite",
+            entries: [{ idx: 0, when: 1, tag: "0000_initial", breakpoints: true }],
+        };
+        const head = {
+            version: "8",
+            dialect: "sqlite",
+            entries: [{ idx: 0, when: 1, tag: "0000_rewritten", breakpoints: true }],
+        };
+        const errors = validateJournalHistory(base, head);
+        assert.ok(errors.some(error => error.includes("metadata is immutable")));
+        assert.ok(errors.some(error => error.includes("entry 0 is immutable")));
+    });
+
+    it("rejects malformed appended journal entries", () => {
+        const base = { version: "7", dialect: "sqlite", entries: [] };
+        const head = {
+            ...base,
+            entries: [{ idx: 4, when: 0, tag: "wrong", breakpoints: "yes" }],
+        };
+        const errors = validateJournalHistory(base, head, "0000_generated.sql");
+        assert.ok(errors.some(error => error.includes("tag")));
+        assert.ok(errors.some(error => error.includes("index")));
+        assert.ok(errors.some(error => error.includes("malformed")));
+    });
+});

--- a/test/migration-history-safety.test.mjs
+++ b/test/migration-history-safety.test.mjs
@@ -28,6 +28,14 @@ describe("migration history safety", () => {
         assert.equal(errors.filter(error => error.includes("immutable")).length, 2);
     });
 
+    it("rejects a snapshot whose index differs from the added migration", () => {
+        const errors = validateMigrationChanges([
+            { status: "A", paths: ["examples/hono/drizzle/0002_a.sql"] },
+            { status: "A", paths: ["examples/hono/drizzle/meta/0003_snapshot.json"] },
+        ]);
+        assert.ok(errors.some(error => error.includes("share one index")));
+    });
+
     it("rejects multiple or unmatched generated additions", () => {
         const errors = validateMigrationChanges([
             { status: "A", paths: ["examples/hono/drizzle/0002_a.sql"] },

--- a/test/sql-migration-safety.test.mjs
+++ b/test/sql-migration-safety.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { rejectUnsafeDml } from "../scripts/sql-migration-safety.mjs";
+
+describe("migration SQL safety", () => {
+    it("accepts a generated Drizzle table-rebuild copy", () => {
+        assert.doesNotThrow(() =>
+            rejectUnsafeDml(
+                "0001_generated.sql",
+                'INSERT INTO `__new_users`("id", "name") SELECT "id", "name" FROM `users`;'
+            )
+        );
+    });
+
+    for (const [name, sql] of [
+        ["delete after DDL", "CREATE TABLE temp (id text); DELETE FROM users;"],
+        ["update after DDL", "ALTER TABLE users ADD name text; UPDATE users SET name = 'x';"],
+        ["insert after DDL", "CREATE TABLE temp (id text); INSERT INTO temp VALUES ('x');"],
+        ["insert with a block comment", "INSERT/* generated? */INTO audit VALUES ('x');"],
+        ["insert with a line comment", "INSERT-- generated?\nINTO audit VALUES ('x');"],
+        ["insert or ignore", "INSERT OR IGNORE INTO audit VALUES ('x');"],
+        ["insert or replace", "INSERT OR REPLACE INTO audit VALUES ('x');"],
+        ["replace after DDL", "CREATE TABLE temp (id text); REPLACE INTO temp VALUES ('x');"],
+        [
+            "second insert after a table copy",
+            'INSERT INTO `__new_users`("id") SELECT "id" FROM `users`; INSERT INTO audit VALUES (1);',
+        ],
+    ]) {
+        it(`rejects ${name}`, () => {
+            assert.throws(() => rejectUnsafeDml("tampered.sql", sql), /not a single Drizzle table-rebuild copy/);
+        });
+    }
+
+    it("does not classify SQL keywords inside quoted values as DML", () => {
+        assert.doesNotThrow(() =>
+            rejectUnsafeDml(
+                "quoted.sql",
+                "CREATE TABLE notes (template text DEFAULT 'DELETE FROM users', label text DEFAULT 'INSERT INTO');"
+            )
+        );
+    });
+
+    it("does not split breakpoint text inside quotes or comments", () => {
+        assert.doesNotThrow(() =>
+            rejectUnsafeDml(
+                "quoted-breakpoint.sql",
+                "CREATE TABLE notes (template text DEFAULT 'prefix --> statement-breakpoint DELETE FROM users');\n-- --> statement-breakpoint DELETE FROM users"
+            )
+        );
+    });
+});


### PR DESCRIPTION
Split from #64. Adds four scripts and a CI step per example that reject rewritten migration history, reproduce the latest migration with the pinned `drizzle-kit`, replay the SQLite chain, and fail on `auth.schema.ts` or migration drift. No library changes. The examples gain `db:check` (and OpenNext `typecheck`) scripts and an exact `drizzle-kit` pin so the byte comparison is stable; their code, schema, and migrations are untouched.

| Check (local, against `origin/main`) | hono | opennextjs |
| --- | --- | --- |
| `verify-migration-history.mjs` | pass | pass |
| `auth:update` → `db:generate` | no schema changes | no schema changes |
| `drizzle-kit check` + `db:check` | pass | pass |
| `git diff --exit-code src/db drizzle` | clean | clean |
| `pnpm typecheck` | n/a | pass |
| root `pnpm test:unit` | 29 pass (23 new) | |