### PR TITLE
fix: generated Hyperdrive projects and Hono example secret

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1248,7 +1248,7 @@ async function generate(cliArgs?: CliArgs) {
                     deps["postgres"] = deps["postgres"] || "^3.4.5";
                 }
                 if (answers.database === "hyperdrive-mysql") {
-                    deps["mysql2"] = deps["mysql2"] || "^3.9.7";
+                    deps["mysql2"] = deps["mysql2"] || "^3.14.0";
                 }
                 const scripts = (j.scripts as JSONObject) || {};
                 for (const key of Object.keys(scripts)) {
@@ -1392,6 +1392,7 @@ export const verification = {} as any;`;
             hyperdrive: answers.hdBinding,
         },
         skipCloudflareSetup: answers.skipCloudflareSetup,
+        database: answers.database,
         resourceIds: {
             r2BucketName: answers.r2BucketName,
             ...resourceIds,

--- a/cli/src/lib/auth-generator.ts
+++ b/cli/src/lib/auth-generator.ts
@@ -37,6 +37,7 @@ function generateHonoAuth(config: AuthConfig): string {
         imports.push(`import { drizzle } from "drizzle-orm/d1";`);
     } else if (config.database === "postgres") {
         imports.push(`import { drizzle } from "drizzle-orm/postgres-js";`);
+        imports.push(`import postgres from "postgres";`);
     } else {
         imports.push(`import { drizzle } from "drizzle-orm/mysql2";`);
         imports.push(`import mysql from "mysql2";`);
@@ -53,9 +54,11 @@ function generateHonoAuth(config: AuthConfig): string {
 function createAuth(env?: CloudflareBindings, cf?: IncomingRequestCfProperties, baseURL?: string) {
     // Use actual DB for runtime, empty object for CLI
     const db = env ? ${generateDbConnection(config)} : ({} as any);
+    if (env && !env.BETTER_AUTH_SECRET) throw new Error("BETTER_AUTH_SECRET is not set.");
 
     return betterAuth({
         baseURL,
+        secret: env?.BETTER_AUTH_SECRET,
         ...withCloudflare(
             {
                 autoDetectIpAddress: true,
@@ -106,6 +109,21 @@ function generateNextjsAuth(config: AuthConfig): string {
 
     const cloudflareConfig = generateNextjsCloudflareConfig(config);
     const cliDatabaseConfig = generateCliDatabaseConfig(config);
+    // Hyperdrive sockets cannot be shared across requests, so only D1 keeps a singleton.
+    const initializer = config.resources.hyperdrive
+        ? `export async function initAuth() {
+    return authBuilder();
+}`
+        : `// Singleton pattern to ensure a single auth instance
+let authInstance: Awaited<ReturnType<typeof authBuilder>> | null = null;
+
+// Asynchronously initializes and retrieves the shared auth instance
+export async function initAuth() {
+    if (!authInstance) {
+        authInstance = await authBuilder();
+    }
+    return authInstance;
+}`;
 
     return `${imports.join("\n")}
 
@@ -132,16 +150,7 @@ async function authBuilder() {
     });
 }
 
-// Singleton pattern to ensure a single auth instance
-let authInstance: Awaited<ReturnType<typeof authBuilder>> | null = null;
-
-// Asynchronously initializes and retrieves the shared auth instance
-export async function initAuth() {
-    if (!authInstance) {
-        authInstance = await authBuilder();
-    }
-    return authInstance;
-}
+${initializer}
 
 /* ======================================================================= */
 /* Configuration for Schema Generation                                     */
@@ -187,9 +196,14 @@ function generateHonoCloudflareConfig(config: AuthConfig): string {
                     : undefined,`);
     } else if (config.resources.hyperdrive) {
         parts.push(`
-                ${config.database === "postgres" ? "postgres" : "mysql"}: {
-                    db
-                },`);
+                ${config.database === "postgres" ? "postgres" : "mysql"}: env
+                    ? {
+                          db,
+                          options: {
+                              usePlural: true,
+                          },
+                      }
+                    : undefined,`);
     }
 
     // KV configuration
@@ -266,7 +280,10 @@ function generateNextjsCloudflareConfig(config: AuthConfig): string {
     } else if (config.resources.hyperdrive) {
         parts.push(`
                 ${config.database === "postgres" ? "postgres" : "mysql"}: {
-                    db: dbInstance
+                    db: dbInstance,
+                    options: {
+                        usePlural: true,
+                    },
                 },`);
     }
 
@@ -354,15 +371,9 @@ function generateDbConnection(config: AuthConfig): string {
     if (config.database === "sqlite") {
         return `drizzle(env.${config.bindings.d1 || "DATABASE"}, { schema, logger: true })`;
     } else if (config.database === "postgres") {
-        return `drizzle(env.${binding}, { schema, logger: true })`;
+        return `drizzle(postgres(env.${binding}.connectionString, { max: 5, fetch_types: false, prepare: true }), { schema, logger: true })`;
     } else {
-        return `drizzle(mysql.createPool({
-        host: env.${binding}.host,
-        user: env.${binding}.user,
-        password: env.${binding}.password,
-        database: env.${binding}.database,
-        port: env.${binding}.port,
-    }), { schema, mode: "default", logger: true })`;
+        return `drizzle(mysql.createPool({ uri: env.${binding}.connectionString, disableEval: true }), { schema, mode: "default", logger: true })`;
     }
 }
 

--- a/cli/src/lib/db-generator.ts
+++ b/cli/src/lib/db-generator.ts
@@ -50,7 +50,7 @@ function generateNextjsImports(config: DbConfig): string {
         imports.push('import postgres from "postgres";');
     } else {
         imports.push('import { drizzle } from "drizzle-orm/mysql2";');
-        imports.push('import mysql from "mysql2/promise";');
+        imports.push('import mysql from "mysql2";');
     }
 
     imports.push('import { schema } from "./schema";');
@@ -80,7 +80,7 @@ function generateGetDbFunction(config: DbConfig): string {
     const { env } = await getCloudflareContext({ async: true });
 
     // Initialize Drizzle with your Hyperdrive binding for PostgreSQL
-    return drizzle(postgres(env.${binding}.connectionString), {
+    return drizzle(postgres(env.${binding}.connectionString, { max: 5, fetch_types: false, prepare: true }), {
         // Ensure "${binding}" matches your Hyperdrive binding name in wrangler.toml
         schema,
         logger: true, // Optional
@@ -92,10 +92,11 @@ function generateGetDbFunction(config: DbConfig): string {
     const { env } = await getCloudflareContext({ async: true });
 
     // Initialize Drizzle with your Hyperdrive binding for MySQL
-    const pool = await mysql.createPool(env.${binding}.connectionString);
+    const pool = mysql.createPool({ uri: env.${binding}.connectionString, disableEval: true });
     return drizzle(pool, {
         // Ensure "${binding}" matches your Hyperdrive binding name in wrangler.toml
         schema,
+        mode: "default",
     });
 }`;
     }

--- a/cli/src/lib/wrangler-generator.ts
+++ b/cli/src/lib/wrangler-generator.ts
@@ -14,6 +14,7 @@ export interface WranglerConfig {
         hyperdrive?: string;
     };
     skipCloudflareSetup?: boolean;
+    database?: "d1" | "hyperdrive-postgres" | "hyperdrive-mysql";
     resourceIds?: {
         d1?: string;
         kv?: string;
@@ -50,7 +51,7 @@ function generateBasicConfig(config: WranglerConfig): string {
     return `
 name = "${config.appName}"
 main = "${main}"
-compatibility_date = "2025-03-01"
+compatibility_date = "2025-04-01"
 compatibility_flags = ${compatibilityFlags}`;
 }
 
@@ -125,7 +126,10 @@ bucket_name = "${bucketName}"`);
 
         // Add proper localConnectionString for Next.js builds
         const localConnectionString =
-            config.resourceIds?.hyperdriveConnectionString || "postgresql://postgres:password@localhost:5432/postgres";
+            config.resourceIds?.hyperdriveConnectionString ||
+            (config.database === "hyperdrive-mysql"
+                ? "mysql://root:password@localhost:3306/mysql"
+                : "postgresql://postgres:password@localhost:5432/postgres");
 
         resources.push(`
 [[hyperdrive]]

--- a/cli/tests/auth-generator.test.ts
+++ b/cli/tests/auth-generator.test.ts
@@ -17,6 +17,9 @@ describe("Auth Generator", () => {
             // Check imports
             expect(result).toContain('import { drizzle } from "drizzle-orm/d1"');
             expect(result).toContain('import { schema } from "../db"');
+            expect(result).toContain(
+                'if (env && !env.BETTER_AUTH_SECRET) throw new Error("BETTER_AUTH_SECRET is not set.");'
+            );
             expect(result).toContain('import type { CloudflareBindings } from "../env"');
 
             // Check D1 configuration
@@ -46,14 +49,17 @@ describe("Auth Generator", () => {
 
             // Check imports
             expect(result).toContain('import { drizzle } from "drizzle-orm/postgres-js"');
+            expect(result).toContain('import postgres from "postgres"');
+            expect(result).toContain(
+                "postgres(env.HYPERDRIVE.connectionString, { max: 5, fetch_types: false, prepare: true })"
+            );
             expect(result).not.toContain('import { drizzle } from "drizzle-orm/d1"');
 
             // Check PostgreSQL configuration
-            expect(result).toContain("postgres: {");
-            expect(result).toContain("db");
+            expect(result).toContain("postgres: env");
             expect(result).toContain('provider: "pg"');
+            expect(result.match(/usePlural: true/g)).toHaveLength(2);
 
-            // Should not contain D1
             expect(result).not.toContain("d1: env");
         });
 
@@ -149,9 +155,25 @@ describe("Auth Generator", () => {
             expect(result).toContain("postgres: {");
             expect(result).toContain("db: dbInstance");
             expect(result).toContain('provider: "pg"');
+            expect(result.match(/usePlural: true/g)).toHaveLength(2);
 
             // Should not contain D1
             expect(result).not.toContain("d1: {");
+        });
+
+        test("generates Hyperdrive MySQL configuration without a shared auth instance", () => {
+            const result = generateAuthFile({
+                template: "nextjs",
+                database: "mysql",
+                resources: { d1: false, kv: false, r2: false, hyperdrive: true },
+                bindings: { hyperdrive: "HYPERDRIVE" },
+            });
+
+            expect(result).toContain("mysql: {");
+            expect(result).toContain('provider: "mysql"');
+            expect(result.match(/usePlural: true/g)).toHaveLength(2);
+            expect(result).not.toContain("authInstance");
+            expect(result).toContain("export async function initAuth() {\n    return authBuilder();");
         });
 
         test("generates KV configuration with custom binding", () => {
@@ -229,6 +251,10 @@ describe("Auth Generator", () => {
             const result = generateAuthFile(config);
 
             expect(result).toContain('import { drizzle } from "drizzle-orm/mysql2"');
+            expect(result).toContain("mysql.createPool({ uri: env.HYPERDRIVE.connectionString, disableEval: true })");
+            expect(result).toContain('mode: "default"');
+            expect(result).toContain("mysql: env");
+            expect(result.match(/usePlural: true/g)).toHaveLength(2);
             expect(result).toContain('provider: "mysql"');
             expect(result).toContain("drizzleAdapter({} as any");
         });

--- a/cli/tests/db-generator.test.ts
+++ b/cli/tests/db-generator.test.ts
@@ -88,7 +88,9 @@ describe("Database Generator", () => {
             expect(result).toContain('import { drizzle } from "drizzle-orm/postgres-js"');
             expect(result).toContain('import postgres from "postgres"');
             expect(result).toContain("export async function getDb()");
-            expect(result).toContain("postgres(env.HYPERDRIVE.connectionString)");
+            expect(result).toContain(
+                "postgres(env.HYPERDRIVE.connectionString, { max: 5, fetch_types: false, prepare: true })"
+            );
             expect(result).toContain('// Ensure "HYPERDRIVE" matches your Hyperdrive binding name');
         });
 
@@ -101,7 +103,9 @@ describe("Database Generator", () => {
 
             const result = generateDbIndex(config);
 
-            expect(result).toContain("postgres(env.MY_HYPERDRIVE.connectionString)");
+            expect(result).toContain(
+                "postgres(env.MY_HYPERDRIVE.connectionString, { max: 5, fetch_types: false, prepare: true })"
+            );
             expect(result).toContain('// Ensure "MY_HYPERDRIVE" matches your Hyperdrive binding name');
         });
     });
@@ -117,9 +121,9 @@ describe("Database Generator", () => {
             const result = generateDbIndex(config);
 
             expect(result).toContain('import { drizzle } from "drizzle-orm/mysql2"');
-            expect(result).toContain('import mysql from "mysql2/promise"');
+            expect(result).toContain('import mysql from "mysql2"');
             expect(result).toContain("export async function getDb()");
-            expect(result).toContain("mysql.createPool(env.HYPERDRIVE.connectionString)");
+            expect(result).toContain("mysql.createPool({ uri: env.HYPERDRIVE.connectionString, disableEval: true })");
             expect(result).toContain('// Ensure "HYPERDRIVE" matches your Hyperdrive binding name');
         });
 
@@ -132,7 +136,9 @@ describe("Database Generator", () => {
 
             const result = generateDbIndex(config);
 
-            expect(result).toContain("mysql.createPool(env.MY_HYPERDRIVE.connectionString)");
+            expect(result).toContain(
+                "mysql.createPool({ uri: env.MY_HYPERDRIVE.connectionString, disableEval: true })"
+            );
             expect(result).toContain('// Ensure "MY_HYPERDRIVE" matches your Hyperdrive binding name');
         });
     });
@@ -174,7 +180,7 @@ describe("Database Generator", () => {
             const mysqlResult = generateDbIndex(mysqlConfig);
 
             expect(postgresResult).toContain('import postgres from "postgres"');
-            expect(mysqlResult).toContain('import mysql from "mysql2/promise"');
+            expect(mysqlResult).toContain('import mysql from "mysql2"');
         });
     });
 
@@ -206,11 +212,16 @@ describe("Database Generator", () => {
             expect(sqliteResult).toContain("drizzle(env.DATABASE, {");
 
             // PostgreSQL should use postgres connection
-            expect(postgresResult).toContain("drizzle(postgres(env.HYPERDRIVE.connectionString), {");
+            expect(postgresResult).toContain(
+                "drizzle(postgres(env.HYPERDRIVE.connectionString, { max: 5, fetch_types: false, prepare: true }), {"
+            );
 
             // MySQL should use pool creation
-            expect(mysqlResult).toContain("const pool = await mysql.createPool(env.HYPERDRIVE.connectionString)");
+            expect(mysqlResult).toContain(
+                "const pool = mysql.createPool({ uri: env.HYPERDRIVE.connectionString, disableEval: true })"
+            );
             expect(mysqlResult).toContain("return drizzle(pool, {");
+            expect(mysqlResult).toContain('mode: "default"');
         });
     });
 

--- a/cli/tests/wrangler-generator.test.ts
+++ b/cli/tests/wrangler-generator.test.ts
@@ -4,6 +4,19 @@ import type { WranglerConfig } from "../src/lib/wrangler-generator";
 
 describe("Wrangler Generator", () => {
     describe("Basic Configuration", () => {
+        test("defaults the MySQL local connection string", () => {
+            const result = generateWranglerToml({
+                appName: "app",
+                template: "hono",
+                resources: { d1: false, kv: false, r2: false, hyperdrive: true },
+                bindings: {},
+                skipCloudflareSetup: true,
+                database: "hyperdrive-mysql",
+            });
+
+            expect(result).toContain('localConnectionString = "mysql://root:password@localhost:3306/mysql"');
+        });
+
         test("generates Hono basic configuration", () => {
             const config: WranglerConfig = {
                 appName: "test-hono-app",
@@ -17,6 +30,7 @@ describe("Wrangler Generator", () => {
             expect(result).toContain('name = "test-hono-app"');
             expect(result).toContain('main = "src/index.ts"');
             expect(result).toContain('compatibility_flags = ["nodejs_compat"]');
+            expect(result).toContain('compatibility_date = "2025-04-01"');
             expect(result).toContain("[observability]");
             expect(result).toContain("[placement]");
             expect(result).not.toContain("[assets]");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -252,7 +252,7 @@ Complete example with all supported binding types. Include only what you need.
 ```toml
 name = "my-auth-app"
 main = "src/index.ts"
-compatibility_date = "2025-03-01"
+compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
 [observability]

--- a/examples/hono/README.md
+++ b/examples/hono/README.md
@@ -156,6 +156,12 @@ interface CloudflareBindings {
 }
 ```
 
+Set the session secret before deploying; without it Better Auth signs sessions with a default secret:
+
+```bash
+openssl rand -base64 48 | wrangler secret put BETTER_AUTH_SECRET
+```
+
 ### Better Auth Configuration
 
 The auth configuration in `src/auth/index.ts` uses a simplified single-function approach that handles both CLI schema generation and runtime scenarios:

--- a/examples/hono/src/auth/index.ts
+++ b/examples/hono/src/auth/index.ts
@@ -10,9 +10,11 @@ import type { CloudflareBindings } from "../env";
 // Single auth configuration that handles both CLI and runtime scenarios
 function createAuth(env?: CloudflareBindings, cf?: IncomingRequestCfProperties, baseURL?: string) {
     const db = env ? drizzle(env.DATABASE, { schema, logger: true }) : ({} as any);
+    if (env && !env.BETTER_AUTH_SECRET) throw new Error("BETTER_AUTH_SECRET is not set.");
 
     return betterAuth({
         baseURL,
+        secret: env?.BETTER_AUTH_SECRET,
         ...withCloudflare(
             {
                 autoDetectIpAddress: true,

--- a/examples/hono/wrangler.toml
+++ b/examples/hono/wrangler.toml
@@ -3,7 +3,7 @@
 
 name = "better-auth-cloudflare-hono"
 main = "src/index.ts"
-compatibility_date = "2025-03-01"
+compatibility_date = "2025-04-01"
 compatibility_flags = ["nodejs_compat"]
 
 [observability]


### PR DESCRIPTION
What is broken on `main` today, nothing else:

- Hyperdrive projects generated by the CLI throw on their first query: the schema is generated with `usePlural`, the runtime adapter ran without it.
- Hono + Hyperdrive Postgres passed the binding straight to `drizzle()`. Now `drizzle(postgres(env.HYPERDRIVE.connectionString, { max: 5, fetch_types: false, prepare: true }))`, the shape Cloudflare documents.
- MySQL templates used a pool without `disableEval`, which Workers reject, and the Next.js one used `mysql2/promise`, whose pool type the library's `DrizzleConfig` rejects. Both now use the callback `mysql2` pool with `disableEval: true`; Next.js also gains the required `mode`.
- MySQL projects got a Postgres `localConnectionString`.
- The Next.js singleton cached a Hyperdrive pool across requests, which Workers reject; Hyperdrive projects now build auth per request.
- Hono projects never saw `BETTER_AUTH_SECRET`: `compatibility_date = "2025-03-01"` predates workerd populating `process.env`, so Better Auth signed sessions with its default secret. Verified on the live Hono demo: its session cookie validated against the default secret. The template and example now pass `secret: env.BETTER_AUTH_SECRET` explicitly and use `2025-04-01`; the Hono README says how to set it.

| Check | main | branch |
| --- | --- | --- |
| `bun test tests/*.test.ts` (cli) | 236 | 238 |
| generated `tsc --noEmit`: hono d1/pg/mysql, next d1/pg/mysql | 2/6 pass | 6/6 pass |
| generated Hono Hyperdrive `auth:update` (schema generation) | n/a | pass |
| `wrangler dev` secret rotation, session replayed | survives at 2025-03-01 | rejected at 2025-04-01 |
| live Hono demo, deployed from this branch | cookie signed with default secret | signed with `BETTER_AUTH_SECRET`; forged default-secret cookie rejected |