### PR TITLE
fix: resolve geolocation per request for shared auth instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ bun add better-auth-cloudflare
 
 ## Configuration Options
 
-| Option                | Type    | Default     | Description                                    |
-| --------------------- | ------- | ----------- | ---------------------------------------------- |
-| `autoDetectIpAddress` | boolean | `true`      | Auto-detect IP address from Cloudflare headers |
-| `geolocationTracking` | boolean | `true`      | Track geolocation data in the session table    |
-| `cf`                  | object  | `{}`        | Cloudflare geolocation context                 |
-| `r2`                  | object  | `undefined` | R2 bucket configuration for file storage       |
+| Option                | Type               | Default     | Description                                                                              |
+| --------------------- | ------------------ | ----------- | ---------------------------------------------------------------------------------------- |
+| `autoDetectIpAddress` | boolean            | `true`      | Auto-detect IP address from Cloudflare headers                                           |
+| `geolocationTracking` | boolean            | `true`      | Track geolocation data in the session table                                              |
+| `cf`                  | object or function | `undefined` | Request geolocation context; pass a function when one auth instance serves many requests |
+| `r2`                  | object             | `undefined` | R2 bucket configuration for file storage                                                 |
 
 For the full `WithCloudflareOptions` interface (including database, KV, and Drizzle adapter options), see the [Configuration Reference](./docs/configuration.md).
 

--- a/cli/src/lib/auth-generator.ts
+++ b/cli/src/lib/auth-generator.ts
@@ -138,7 +138,7 @@ async function authBuilder() {
             {
                 autoDetectIpAddress: true,
                 geolocationTracking: true,
-                cf: cfCtx.cf,${cloudflareConfig}
+                cf: () => getCloudflareContext().cf,${cloudflareConfig}
             },
             {
                 baseURL: cfCtx.env.BETTER_AUTH_URL,

--- a/cli/tests/auth-generator.test.ts
+++ b/cli/tests/auth-generator.test.ts
@@ -134,6 +134,8 @@ describe("Auth Generator", () => {
             expect(result).toContain("db: dbInstance");
             expect(result).toContain("usePlural: true");
 
+            expect(result).toContain("cf: () => getCloudflareContext().cf");
+
             // Check async auth builder pattern
             expect(result).toContain("async function authBuilder()");
             expect(result).toContain("let authInstance");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,12 +85,12 @@ The `provider` is inferred from which option you use (`"sqlite"` / `"pg"` / `"my
 
 Inherited by `WithCloudflareOptions`.
 
-| Option                | Type                                          | Default     | Description                                                                                                                   |
-| --------------------- | --------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `autoDetectIpAddress` | `boolean`                                     | `true`      | Adds `cf-connecting-ip` and `x-real-ip` to IP detection headers.                                                              |
-| `geolocationTracking` | `boolean`                                     | `true`      | Enriches sessions with geolocation fields. Overrides `session.storeSessionInDatabase` to `true`.                              |
-| `cf`                  | `CloudflareGeolocation \| Promise<…> \| null` | `undefined` | **Required** unless both options above are disabled. Typically `request.cf` (Hono) or `getCloudflareContext().cf` (OpenNext). |
-| `r2`                  | `R2Config`                                    | `undefined` | R2 bucket configuration. See the [R2 File Storage Guide](./r2.md).                                                            |
+| Option                | Type                                                       | Default     | Description                                                                                                                                                      |
+| --------------------- | ---------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autoDetectIpAddress` | `boolean`                                                  | `true`      | Adds `cf-connecting-ip` and `x-real-ip` to IP detection headers.                                                                                                 |
+| `geolocationTracking` | `boolean`                                                  | `true`      | Enriches sessions with geolocation fields. Overrides `session.storeSessionInDatabase` to `true`.                                                                 |
+| `cf`                  | `CloudflareGeolocation \| Promise<…> \| (() => …) \| null` | `undefined` | **Required** unless both options above are disabled. Use `request.cf` in Hono, or `() => getCloudflareContext().cf` when one auth instance serves many requests. |
+| `r2`                  | `R2Config`                                                 | `undefined` | R2 bucket configuration. See the [R2 File Storage Guide](./r2.md).                                                                                               |
 
 ### `CloudflareGeolocation`
 

--- a/examples/opennextjs/README.md
+++ b/examples/opennextjs/README.md
@@ -86,7 +86,7 @@ async function authBuilder() {
             {
                 autoDetectIpAddress: true,
                 geolocationTracking: true,
-                cf: cfCtx.cf,
+                cf: () => getCloudflareContext().cf,
                 d1: {
                     db: dbInstance,
                     options: {

--- a/examples/opennextjs/src/auth/index.ts
+++ b/examples/opennextjs/src/auth/index.ts
@@ -13,7 +13,7 @@ async function authBuilder() {
             {
                 autoDetectIpAddress: true,
                 geolocationTracking: true,
-                cf: cfCtx.cf,
+                cf: () => getCloudflareContext().cf,
                 d1: {
                     db: dbInstance,
                     options: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ const createCloudflarePlugin = (options?: CloudflarePluginOptions, validateStora
                         return ctx.json({ error: "Unauthorized" }, { status: 401 });
                     }
 
-                    const cf = await Promise.resolve(opts.cf);
+                    const cf = await resolveCloudflareGeolocation(opts.cf);
                     if (!cf) {
                         return ctx.json({ error: "Cloudflare context is not available" }, { status: 404 });
                     }
@@ -65,7 +65,7 @@ const createCloudflarePlugin = (options?: CloudflarePluginOptions, validateStora
                                     _context: GenericEndpointContext | null
                                 ) => {
                                     if (!geolocationTrackingEnabled) return;
-                                    const cf = await Promise.resolve(opts.cf);
+                                    const cf = await resolveCloudflareGeolocation(opts.cf);
                                     if (!cf) return;
                                     const geoData = extractGeolocationData(cf);
                                     return {
@@ -157,6 +157,10 @@ function assertAtomicStorageCompatibility(version: string, options: BetterAuthOp
                 "Route verification and rate limiting to the database or provide atomic storage."
         );
     }
+}
+
+async function resolveCloudflareGeolocation(source: CloudflarePluginOptions["cf"]) {
+    return typeof source === "function" ? source() : source;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ import type { drizzle as d1Drizzle } from "drizzle-orm/d1";
 import type { drizzle as mysqlDrizzle } from "drizzle-orm/mysql2";
 import type { drizzle as postgresDrizzle } from "drizzle-orm/postgres-js";
 
+type CloudflareGeolocationSource = CloudflareGeolocation | null | undefined;
+
 export interface CloudflarePluginOptions {
     /**
      * Auto-detect IP address
@@ -20,9 +22,13 @@ export interface CloudflarePluginOptions {
     geolocationTracking?: boolean;
 
     /**
-     * Cloudflare geolocation context
+     * Cloudflare geolocation context, or a function that resolves it per
+     * request when one auth instance serves many requests.
      */
-    cf?: CloudflareGeolocation | Promise<CloudflareGeolocation | null> | null;
+    cf?:
+        | CloudflareGeolocationSource
+        | Promise<CloudflareGeolocationSource>
+        | (() => CloudflareGeolocationSource | Promise<CloudflareGeolocationSource>);
 
     /**
      * R2 configuration for user file tracking

--- a/test/kv-storage.test.mjs
+++ b/test/kv-storage.test.mjs
@@ -105,6 +105,31 @@ describe("withCloudflare storage wiring", () => {
         assert.deepEqual(Object.keys(result.secondaryStorage).sort(), ["delete", "get", "set"]);
     });
 
+    it("resolves geolocation per request when cf is a function", async () => {
+        let cf = { city: "Paris", country: "FR" };
+        const options = withCloudflare({ autoDetectIpAddress: false, geolocationTracking: true, cf: () => cf }, {});
+        const hook = initializeCloudflarePlugin(options, "1.7.3").options.databaseHooks.session.create.before;
+
+        const first = await hook({}, null);
+        cf = { city: "Tokyo", country: "JP" };
+        const second = await hook({}, null);
+
+        assert.equal(first.data.city, "Paris");
+        assert.equal(second.data.city, "Tokyo");
+    });
+
+    it("accepts async resolvers and skips geolocation when they resolve to nothing", async () => {
+        const hookFor = cf =>
+            initializeCloudflarePlugin(
+                withCloudflare({ autoDetectIpAddress: false, geolocationTracking: true, cf }, {}),
+                "1.7.3"
+            ).options.databaseHooks.session.create.before;
+
+        assert.equal((await hookFor(async () => ({ city: "Lima" }))({}, null)).data.city, "Lima");
+        assert.equal(await hookFor(async () => undefined)({}, null), undefined);
+        assert.equal(await hookFor(() => null)({}, null), undefined);
+    });
+
     it("leaves Better Auth 1.5 and 1.6 KV configurations alone", () => {
         const result = withCloudflare({ ...cloudflareOptions, kv: createKV() }, {});
 


### PR DESCRIPTION
The OpenNext example and the Next.js CLI template build one `betterAuth()` instance and capture `cfCtx.cf` from the request that created it, so every session created afterwards is stored with the first visitor's city, country, and timezone, and `/cloudflare/geolocation` returns that visitor's location to everyone. `cf` now also accepts a function (sync or async, may resolve to nothing); the plugin calls it on every session creation and geolocation request. The example and template pass `() => getCloudflareContext().cf`. Hono is unaffected (it builds auth per request).

| Check | main | branch |
| --- | --- | --- |
| session hook with `cf: () => current` after `current` changes | second session gets first value | second session gets new value (unit test) |
| async resolver / resolver returning nothing | n/a | Lima / hook skipped (unit tests) |
| `async () => (await getCloudflareContext({ async: true })).cf` typechecks | n/a | yes (strict probe) |
| `pnpm test:unit` (root) | 20 | 22 |
| `bun test tests/*.test.ts` (cli) | 238 | 238 |
| OpenNext example `tsc --noEmit` | pass | pass |
| generated Next.js project `tsc` against a packed build of this branch | n/a | pass |
| live OpenNext deployed from this branch | n/a | session `city` and `/cloudflare/geolocation` come from the request |

The CLI template change needs the library published first: generated projects install `better-auth-cloudflare` from npm, and 0.3.1 rejects the function form.